### PR TITLE
Fix Maven Central publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 build
 .idea
 debug_publish.log
+supertool
 

--- a/buildSrc/src/main/kotlin/publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/publishing-convention.gradle.kts
@@ -1,3 +1,4 @@
+import com.vanniktech.maven.publish.SonatypeHost
 import org.gradle.api.tasks.javadoc.Javadoc
 
 plugins {
@@ -17,7 +18,7 @@ tasks.withType<Javadoc> {
 }
 
 mavenPublishing {
-    publishToMavenCentral()
+    publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
     signAllPublications()
     pom {
         name = "kiwiproc"

--- a/buildSrc/src/main/kotlin/publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/publishing-convention.gradle.kts
@@ -1,4 +1,3 @@
-import com.vanniktech.maven.publish.SonatypeHost
 import org.gradle.api.tasks.javadoc.Javadoc
 
 plugins {
@@ -18,7 +17,7 @@ tasks.withType<Javadoc> {
 }
 
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
+    publishToMavenCentral(automaticRelease = true)
     signAllPublications()
     pom {
         name = "kiwiproc"

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     `java-gradle-plugin`
     jacoco
@@ -110,7 +112,7 @@ spotless {
 
 // plugin is published as a library as well, for the shared processorconfig classes
 mavenPublishing {
-    publishToMavenCentral()
+    publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
     signAllPublications()
     pom {
         name = "kiwiproc"

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.vanniktech.maven.publish.SonatypeHost
-
 plugins {
     `java-gradle-plugin`
     jacoco
@@ -112,7 +110,7 @@ spotless {
 
 // plugin is published as a library as well, for the shared processorconfig classes
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
+    publishToMavenCentral(automaticRelease = true)
     signAllPublications()
     pom {
         name = "kiwiproc"

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,1 +1,1 @@
-version = "0.7"
+version = "0.8-SNAPSHOT"


### PR DESCRIPTION
## Summary

- `publishToMavenCentral()` defaulted to `automaticRelease = false`, causing deployments to upload to the Sonatype Central Portal but never be released to Maven Central
- Fixed by calling `publishToMavenCentral(automaticRelease = true)` in both `publishing-convention.gradle.kts` and `gradle-plugin/plugin/build.gradle.kts`
- Also adds `supertool` to `.gitignore` to prevent it blocking `publish.bash`'s clean tree check

## Test plan

- [x] `./publish.bash` ran successfully and published 0.7 to Maven Central and the Gradle Plugin Portal
- [x] Verify https://central.sonatype.com/artifact/org.ethelred.kiwiproc/shared shows 0.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)