### PR TITLE
Stop MySQL testcontainer when Gradle build finishes

### DIFF
--- a/gradle-plugin/plugin/src/main/java/org/ethelred/kiwiproc/gradle/EmbeddedMySQLService.java
+++ b/gradle-plugin/plugin/src/main/java/org/ethelred/kiwiproc/gradle/EmbeddedMySQLService.java
@@ -13,7 +13,7 @@ import liquibase.resource.DirectoryResourceAccessor;
 import org.gradle.api.services.BuildService;
 import org.testcontainers.containers.MySQLContainer;
 
-public abstract class EmbeddedMySQLService implements BuildService<EmbeddedMySQLParams> {
+public abstract class EmbeddedMySQLService implements BuildService<EmbeddedMySQLParams>, AutoCloseable {
     public static final String DEFAULT_NAME = "embeddedMySQL";
 
     private MySQLContainer<?> container;
@@ -64,5 +64,12 @@ public abstract class EmbeddedMySQLService implements BuildService<EmbeddedMySQL
         }
 
         return new MySQLConnectionInfo(url, c.getUsername(), c.getPassword());
+    }
+
+    @Override
+    public void close() {
+        if (container != null) {
+            container.stop();
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `EmbeddedMySQLService` was starting a `MySQLContainer` but not implementing `AutoCloseable`, so Gradle's BuildService lifecycle never called any cleanup method
- The MySQL container (and Ryuk) remained running for the lifetime of the Gradle daemon after every build
- Adds `AutoCloseable` + `close()` to stop the container at build end, mirroring the existing `EmbeddedH2Service` pattern

## Test plan

- [x] `./gradlew build` passes
- [x] After build completes, `docker ps | grep mysql` returns no results

🤖 Generated with [Claude Code](https://claude.com/claude-code)