### PR TITLE
Add runtime test coverage for previously untested features

### DIFF
--- a/test-any/src/test/java/org/ethelred/kiwiproc/testany/DateTimeTest.java
+++ b/test-any/src/test/java/org/ethelred/kiwiproc/testany/DateTimeTest.java
@@ -1,0 +1,42 @@
+/* (C) Edward Harman 2025 */
+package org.ethelred.kiwiproc.testany;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.postgresql.ds.PGSimpleDataSource;
+
+public class DateTimeTest {
+    static DateTimeDAO dao = initializeDAO();
+
+    private static DateTimeDAO initializeDAO() {
+        var propertiesUrl = DateTimeTest.class.getResource("/application-test.properties");
+        if (propertiesUrl == null) {
+            throw new AssertionError("DB properties not found");
+        }
+        var properties = new Properties();
+        try (var inputStream = propertiesUrl.openStream();
+                var reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
+            properties.load(reader);
+        } catch (IOException e) {
+            throw new AssertionError("Failed to read DB properties file", e);
+        }
+        var dataSource = new PGSimpleDataSource();
+        dataSource.setURL(properties.getProperty("datasources.datetime.url"));
+
+        return new $DateTimeDAO$Provider(dataSource);
+    }
+
+    @Test
+    void insertAndRetrieveTimestamp() {
+        var before = dao.getTestTimestamps().size();
+        dao.nextTimestamp();
+        var after = dao.getTestTimestamps();
+        assertThat(after).hasSize(before + 1);
+        assertThat(after.get(after.size() - 1).createdAt()).isNotNull();
+    }
+}

--- a/test-micronaut/src/main/java/org/ethelred/kiwiproc/testmicronaut/PetClinicDAO.java
+++ b/test-micronaut/src/main/java/org/ethelred/kiwiproc/testmicronaut/PetClinicDAO.java
@@ -75,8 +75,17 @@ public interface PetClinicDAO extends TransactionalDAO<PetClinicDAO> {
             VALUES (:firstName, :lastName)""")
     void addVet(String firstName, String lastName);
 
+    @SqlUpdate("""
+            UPDATE vets SET first_name = :firstName WHERE id = :id""")
+    boolean updateVetFirstName(int id, String firstName);
+
     @SqlBatch("""
             INSERT INTO pets(name, type_id, owner_id)
             VALUES(:name, :type_id, :owner_id)""")
     List<Integer> addPets(List<String> name, List<Integer> typeId, int ownerId);
+
+    @SqlBatch("""
+            INSERT INTO vets(first_name, last_name)
+            VALUES(:firstName, :lastName)""")
+    int[] batchAddVets(List<String> firstName, List<String> lastName);
 }

--- a/test-micronaut/src/test/java/org/ethelred/kiwiproc/testmicronaut/PetClinicTest.java
+++ b/test-micronaut/src/test/java/org/ethelred/kiwiproc/testmicronaut/PetClinicTest.java
@@ -73,6 +73,15 @@ public class PetClinicTest {
     }
 
     @Test
+    void happySetVisitDescription() {
+        var affected = dao.setVisitDescription(1, "updated description");
+        assertThat(affected).isEqualTo(1);
+
+        var notAffected = dao.setVisitDescription(-999, "no match");
+        assertThat(notAffected).isEqualTo(0);
+    }
+
+    @Test
     void happyAddVisit() {
         var visitId =
                 dao.addVisit(new PetClinicDAO.Visit("Jewel", LocalDate.of(2025, Month.JUNE, 13), "Some text here."));
@@ -84,6 +93,31 @@ public class PetClinicTest {
             assertThat(visit).isNotNull();
             assertThat(visit.description()).contains("Some text");
         });
+    }
+
+    @Test
+    void happyUpdateVetFirstNameReturnsBooleanAffectedRows() {
+        var updated = dao.updateVetFirstName(1, "James");
+        assertThat(updated).isTrue();
+
+        var notUpdated = dao.updateVetFirstName(-999, "Nobody");
+        assertThat(notUpdated).isFalse();
+    }
+
+    @Test
+    void happyBatchAddVetsReturnsIntArray() {
+        var message = "rollback batch vet insert";
+        try {
+            dao.run(innerDao -> {
+                var counts = innerDao.batchAddVets(List.of("Batch1", "Batch2"), List.of("Vet1", "Vet2"));
+                assertThat(counts).hasLength(2);
+                assertThat(counts[0]).isEqualTo(1);
+                assertThat(counts[1]).isEqualTo(1);
+                throw new SQLException(message);
+            });
+        } catch (UncheckedSQLException e) {
+            assertThat(e.getCause().getMessage()).isEqualTo(message);
+        }
     }
 
     @Test

--- a/test-spring/src/test/java/org/ethelred/kiwiproc/testspring/PetClinicTest.java
+++ b/test-spring/src/test/java/org/ethelred/kiwiproc/testspring/PetClinicTest.java
@@ -83,6 +83,15 @@ public class PetClinicTest {
     }
 
     @Test
+    void happySetVisitDescription() {
+        var affected = dao.setVisitDescription(1, "updated description");
+        assertThat(affected).isEqualTo(1);
+
+        var notAffected = dao.setVisitDescription(-999, "no match");
+        assertThat(notAffected).isEqualTo(0);
+    }
+
+    @Test
     void happyAddVisit() {
         var visitId =
                 dao.addVisit(new PetClinicDAO.Visit("Jewel", LocalDate.of(2025, Month.JUNE, 13), "Some text here."));


### PR DESCRIPTION
## Summary

- **`DateTimeTest`** (new): exercises `DateTimeDAO` in `test-any`, which was fully generated but had no test class — this covers `LocalDateTime` column mapping, the only `java.time` type not previously runtime-tested
- **`happySetVisitDescription`** (Spring + Micronaut): calls the existing `int`-returning `@SqlUpdate` method that was defined in both DAOs but never invoked; asserts affected count of 1 and 0
- **`updateVetFirstName` + test** (Micronaut): new `boolean`-returning `@SqlUpdate` method covering the true/false affected-rows path, which was only compile-tested before
- **`batchAddVets` + test** (Micronaut): new `int[]`-returning `@SqlBatch` method covering the raw per-statement count return path; the test rolls back via a thrown `SQLException` to keep the database clean

## Test plan

- [ ] `./gradlew :test-any:test` — `DateTimeTest` passes
- [ ] `./gradlew :test-spring:test` — `happySetVisitDescription` passes
- [ ] `./gradlew :test-micronaut:test` — `happySetVisitDescription`, `happyUpdateVetFirstNameReturnsBooleanAffectedRows`, `happyBatchAddVetsReturnsIntArray` all pass
- [ ] `./gradlew build` — full build including spotless check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)