### PR TITLE
Cover remaining medium-priority test gaps

### DIFF
--- a/querymeta/src/test/java/org/ethelred/kiwiproc/meta/H2DialectTest.java
+++ b/querymeta/src/test/java/org/ethelred/kiwiproc/meta/H2DialectTest.java
@@ -19,7 +19,7 @@ class H2DialectTest {
                 arguments("NAME", "name"),
                 arguments("ProductName", "productname"),
                 arguments("already_lower", "already_lower"),
-                arguments("MIXED_CASE", "mixed_case"));
+                arguments("Mixed_Case", "mixed_case"));
     }
 
     @ParameterizedTest

--- a/querymeta/src/test/java/org/ethelred/kiwiproc/meta/H2DialectTest.java
+++ b/querymeta/src/test/java/org/ethelred/kiwiproc/meta/H2DialectTest.java
@@ -1,0 +1,30 @@
+/* (C) Edward Harman 2025 */
+package org.ethelred.kiwiproc.meta;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class H2DialectTest {
+    H2Dialect dialect = new H2Dialect();
+
+    public static Stream<Arguments> normalizeColumnName() {
+        return Stream.of(
+                arguments("id", "id"),
+                arguments("ID", "id"),
+                arguments("NAME", "name"),
+                arguments("ProductName", "productname"),
+                arguments("already_lower", "already_lower"),
+                arguments("MIXED_CASE", "mixed_case"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void normalizeColumnName(String input, String expected) {
+        assertEquals(expected, dialect.normalizeColumnName(input));
+    }
+}

--- a/test-mysql/src/main/java/org/ethelred/kiwiproc/testmysql/ProductDAO.java
+++ b/test-mysql/src/main/java/org/ethelred/kiwiproc/testmysql/ProductDAO.java
@@ -3,6 +3,7 @@ package org.ethelred.kiwiproc.testmysql;
 
 import java.util.List;
 import org.ethelred.kiwiproc.annotation.DAO;
+import org.ethelred.kiwiproc.annotation.SqlBatch;
 import org.ethelred.kiwiproc.annotation.SqlQuery;
 import org.ethelred.kiwiproc.annotation.SqlUpdate;
 import org.jspecify.annotations.Nullable;
@@ -19,6 +20,12 @@ public interface ProductDAO {
 
     @SqlQuery("SELECT id, name, price FROM product ORDER BY id")
     List<Product> listAll();
+
+    @SqlUpdate("DELETE FROM product WHERE id = :id")
+    boolean deleteById(int id);
+
+    @SqlBatch("INSERT INTO product (name, price) VALUES (:name, :price)")
+    int[] batchInsertProducts(List<String> name, List<Double> price);
 
     @SqlUpdate("DELETE FROM product")
     void deleteAll();

--- a/test-mysql/src/test/java/org/ethelred/kiwiproc/testmysql/ProductDAOTest.java
+++ b/test-mysql/src/test/java/org/ethelred/kiwiproc/testmysql/ProductDAOTest.java
@@ -7,6 +7,7 @@ import com.mysql.cj.jdbc.MysqlDataSource;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Properties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,5 +60,24 @@ public class ProductDAOTest {
     void findByIdReturnsNullWhenNotFound() {
         var result = dao.findById(Integer.MAX_VALUE);
         assertThat(result).isNull();
+    }
+
+    @Test
+    void deleteByIdReturnsBooleanAffectedRows() {
+        dao.insertProduct("ToDelete", 5.00);
+        var id = dao.listAll().get(0).id();
+
+        var deleted = dao.deleteById(id);
+        assertThat(deleted).isTrue();
+
+        var notDeleted = dao.deleteById(id);
+        assertThat(notDeleted).isFalse();
+    }
+
+    @Test
+    void batchInsertReturnsCountsArray() {
+        var counts = dao.batchInsertProducts(List.of("BatchA", "BatchB", "BatchC"), List.of(1.0, 2.0, 3.0));
+        assertThat(counts).hasLength(3);
+        assertThat(dao.listAll()).hasSize(3);
     }
 }

--- a/test-spring/src/test/java/org/ethelred/kiwiproc/testspring/PetClinicTest.java
+++ b/test-spring/src/test/java/org/ethelred/kiwiproc/testspring/PetClinicTest.java
@@ -9,6 +9,8 @@ import java.time.Month;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.sql.DataSource;
+import org.ethelred.kiwiproc.exception.UncheckedSQLException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -89,6 +91,19 @@ public class PetClinicTest {
 
         var notAffected = dao.setVisitDescription(-999, "no match");
         assertThat(notAffected).isEqualTo(0);
+    }
+
+    @Test
+    void callRollsBackOnException() {
+        var visitBefore = dao.getVisitById(1);
+        Assertions.assertThrows(
+                UncheckedSQLException.class,
+                () -> dao.<Void>call(innerDao -> {
+                    innerDao.setVisitDescription(1, "Should be rolled back");
+                    throw new SQLException("force rollback");
+                }));
+        var visitAfter = dao.getVisitById(1);
+        assertThat(visitAfter.description()).isEqualTo(visitBefore.description());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **`H2DialectTest`** (querymeta): unit tests for `H2Dialect.normalizeColumnName()`, confirming uppercase column labels from H2 (in non-PostgreSQL mode) are lowercased so they match Java record field names via `NameUtils.equivalent()`
- **MySQL `ProductDAO` + `ProductDAOTest`**: two new methods and tests covering previously untested code paths in a non-PostgreSQL dialect:
  - `boolean deleteById(int id)` — exercises the `boolean` @SqlUpdate return path (true when row matched, false when not)
  - `int[] batchInsertProducts(List<String>, List<Double>)` — exercises the `int[]` @SqlBatch return path via MySQL's `executeBatch()`
- **Spring `PetClinicTest.callRollsBackOnException()`**: verifies that `call()` rolls back the transaction when a `SQLException` is thrown inside the callback — the description of visit 1 is confirmed unchanged after the failed call (analogous to the existing `run()` rollback test in the Micronaut module)

## Test plan

- [ ] `./gradlew :querymeta:test` — `H2DialectTest` passes (6 parameterised cases)
- [ ] `./gradlew :test-mysql:test` — `deleteByIdReturnsBooleanAffectedRows` and `batchInsertReturnsCountsArray` pass
- [ ] `./gradlew :test-spring:test` — `callRollsBackOnException` passes
- [ ] `./gradlew build` — full build including spotless passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)