### PR TITLE
Cover lower-priority test gaps via H2 ProductDAO

### DIFF
--- a/test-h2/src/main/java/org/ethelred/kiwiproc/testh2/ProductDAO.java
+++ b/test-h2/src/main/java/org/ethelred/kiwiproc/testh2/ProductDAO.java
@@ -1,8 +1,10 @@
 /* (C) Edward Harman 2025 */
 package org.ethelred.kiwiproc.testh2;
 
+import java.util.Collection;
 import java.util.List;
 import org.ethelred.kiwiproc.annotation.DAO;
+import org.ethelred.kiwiproc.annotation.SqlBatch;
 import org.ethelred.kiwiproc.annotation.SqlQuery;
 import org.ethelred.kiwiproc.annotation.SqlUpdate;
 import org.jspecify.annotations.Nullable;
@@ -19,6 +21,21 @@ public interface ProductDAO {
 
     @SqlQuery("SELECT id, name, price FROM product ORDER BY id")
     List<Product> listAll();
+
+    @SqlQuery("SELECT id, name, price FROM product ORDER BY id")
+    Collection<Product> listAllAsCollection();
+
+    @SqlQuery("SELECT id, name, price FROM product ORDER BY id")
+    Iterable<Product> listAllAsIterable();
+
+    @SqlQuery("SELECT name FROM product ORDER BY id")
+    String[] listAllNamesAsArray();
+
+    @SqlQuery(value = "SELECT id, name, price FROM product ORDER BY id", fetchSize = 5)
+    List<Product> listAllWithFetchSize();
+
+    @SqlBatch(value = "INSERT INTO product (name, price) VALUES (:name, :price)", batchSize = 2)
+    void batchInsertWithSize(List<String> name, List<Double> price);
 
     @SqlUpdate("DELETE FROM product")
     void deleteAll();

--- a/test-h2/src/test/java/org/ethelred/kiwiproc/testh2/ProductDAOTest.java
+++ b/test-h2/src/test/java/org/ethelred/kiwiproc/testh2/ProductDAOTest.java
@@ -6,6 +6,7 @@ import static com.google.common.truth.Truth.assertThat;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Properties;
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,5 +60,42 @@ public class ProductDAOTest {
     void findByIdReturnsNullWhenNotFound() {
         var result = dao.findById(Integer.MAX_VALUE);
         assertThat(result).isNull();
+    }
+
+    @Test
+    void listAllAsCollectionReturnsProducts() {
+        dao.insertProduct("Alpha", 1.00);
+        dao.insertProduct("Beta", 2.00);
+        var result = dao.listAllAsCollection();
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    void listAllAsIterableReturnsProducts() {
+        dao.insertProduct("Alpha", 1.00);
+        var result = dao.listAllAsIterable();
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void listAllNamesAsArrayReturnsNames() {
+        dao.insertProduct("Widget", 9.99);
+        dao.insertProduct("Gadget", 19.99);
+        var names = dao.listAllNamesAsArray();
+        assertThat(names).asList().containsExactly("Widget", "Gadget").inOrder();
+    }
+
+    @Test
+    void listAllWithFetchSizeReturnsCorrectResults() {
+        dao.insertProduct("X", 1.00);
+        dao.insertProduct("Y", 2.00);
+        var result = dao.listAllWithFetchSize();
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    void batchInsertWithCustomSizeInsertsAllRows() {
+        dao.batchInsertWithSize(List.of("P1", "P2", "P3", "P4", "P5"), List.of(1.0, 2.0, 3.0, 4.0, 5.0));
+        assertThat(dao.listAll()).hasSize(5);
     }
 }


### PR DESCRIPTION
## Summary

All five gaps added to `test-h2`'s `ProductDAO` / `ProductDAOTest`, keeping changes self-contained in one module with clean `@BeforeEach` isolation:

| Gap | Method | Test |
|---|---|---|
| `Collection<T>` return | `listAllAsCollection()` | asserts `hasSize(2)` |
| `Iterable<T>` return | `listAllAsIterable()` | asserts `hasSize(1)` |
| `T[]` return | `listAllNamesAsArray() → String[]` | asserts exact ordered contents |
| `fetchSize` attribute | `listAllWithFetchSize()` — `fetchSize = 5` | verifies correct results still returned |
| `batchSize` attribute | `batchInsertWithSize()` — `batchSize = 2`, 5-element batch | verifies all 5 rows committed |

The `fetchSize` and `batchSize` tests are functional (verify results, not internal JDBC state) since there is no JDBC interception in the integration test suite.

## Test plan

- [ ] `./gradlew :test-h2:test` — all 8 tests pass
- [ ] `./gradlew build` — full build including spotless passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)