### PR TITLE
Fix getSupportedSourceVersion() to return latestSupported()

### DIFF
--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/KiwiProcessor.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/KiwiProcessor.java
@@ -35,9 +35,14 @@ import org.jspecify.annotations.Nullable;
     "org.ethelred.kiwiproc.annotation.ResultQuery",
     "org.ethelred.kiwiproc.annotation.UpdateQuery"
 })
-@SupportedSourceVersion(SourceVersion.RELEASE_17)
 @SupportedOptions({KiwiProcessor.CONFIGURATION_OPTION})
 public class KiwiProcessor extends AnnotationProcessor {
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
+
     public static final String CONFIGURATION_OPTION = "org.ethelred.kiwiproc.configuration";
 
     private ProcessorConfig config = ProcessorConfig.EMPTY;

--- a/processor/src/test/java/org/ethelred/kiwiproc/processor/KiwiProcessorTest.java
+++ b/processor/src/test/java/org/ethelred/kiwiproc/processor/KiwiProcessorTest.java
@@ -1,0 +1,23 @@
+/* (C) Edward Harman 2025 */
+package org.ethelred.kiwiproc.processor;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import org.junit.jupiter.api.Test;
+
+public class KiwiProcessorTest {
+    @Test
+    void supportedSourceVersionIsNotHardCoded() {
+        // @SupportedSourceVersion(RELEASE_17) causes a warning on JVMs newer than 17;
+        // the fix is to remove the annotation and override getSupportedSourceVersion().
+        assertThat(KiwiProcessor.class.getAnnotation(SupportedSourceVersion.class))
+                .isNull();
+    }
+
+    @Test
+    void supportedSourceVersionIsLatest() {
+        assertThat(new KiwiProcessor().getSupportedSourceVersion()).isEqualTo(SourceVersion.latestSupported());
+    }
+}


### PR DESCRIPTION
## Summary

- Removes `@SupportedSourceVersion(SourceVersion.RELEASE_17)` from `KiwiProcessor`
- Overrides `getSupportedSourceVersion()` to return `SourceVersion.latestSupported()`
- Adds `KiwiProcessorTest` to verify the annotation is absent and the method returns the latest version

Fixes #216

## Test plan

- [ ] `./gradlew :processor:test` passes
- [ ] No spurious source version warning when building with Java 21+

🤖 Generated with [Claude Code](https://claude.com/claude-code)