### PR TITLE
Add java.util.UUID as a core type (#316)

### DIFF
--- a/docs/src/docs/asciidoc/types.adoc
+++ b/docs/src/docs/asciidoc/types.adoc
@@ -17,7 +17,7 @@ These are generalized types, not Java or SQL types.
 |V |void
 |I |int or a compatible type
 |P |A primitive or boxed primitive
-|O |Object type. Specifically, one of: String, BigInteger, BigDecimal, LocalDate, LocalTime, OffsetTime, LocalDateTime, OffsetDateTime
+|O |Object type. Specifically, one of: String, BigInteger, BigDecimal, LocalDate, LocalTime, OffsetTime, LocalDateTime, OffsetDateTime, UUID
 |S | P \| O
 |?S |@Nullable (specifically org.jspecify.annotations.Nullable), or Optional<S>. A boxed primitive is also treated as nullable when it is not a type parameter of a container. Optional is only accepted as the return type of a query method.
 |SC<S> | A Collection or array, _only_ in a context where it is mapped to or from a SQL array.

--- a/kiwiproc.allium
+++ b/kiwiproc.allium
@@ -269,7 +269,7 @@ deferred SqlTypeCompatibility.validate
     --   Primitives and boxed: boolean, byte, char, short, int, long, float, double
     --                         (and Boolean, Byte, Character, Short, Integer, Long, Float, Double)
     --   Object types: String, BigInteger, BigDecimal,
-    --                 LocalDate, LocalTime, OffsetTime, LocalDateTime, OffsetDateTime
+    --                 LocalDate, LocalTime, OffsetTime, LocalDateTime, OffsetDateTime, UUID
     --
     -- java.util.UUID is not a core type and is not supported for direct binding.
 

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/CoreTypes.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/CoreTypes.java
@@ -23,6 +23,8 @@ import java.util.stream.Stream;
 import org.ethelred.kiwiproc.processor.types.*;
 import org.jspecify.annotations.Nullable;
 
+import java.util.UUID;
+
 public class CoreTypes {
     public static final ObjectType STRING_TYPE =
             new ObjectType(String.class.getPackageName(), String.class.getSimpleName(), false);
@@ -34,7 +36,8 @@ public class CoreTypes {
             LocalTime.class,
             OffsetTime.class,
             LocalDateTime.class,
-            OffsetDateTime.class);
+            OffsetDateTime.class,
+            UUID.class);
 
     public static final Map<Class<?>, Class<?>> primitiveToBoxed = Map.ofEntries(
             entry(boolean.class, Boolean.class),
@@ -92,6 +95,7 @@ public class CoreTypes {
         addPrimitiveParseMappings(entries);
         addBigNumberMappings(entries);
         addDateTimeMappings(entries);
+        addUUIDMappings(entries);
 
         return entries.stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (a, b) -> a, LinkedHashMap::new));
@@ -168,6 +172,16 @@ public class CoreTypes {
                 "$2N.atStartOfDay().atZone($1T.systemDefault()).toOffsetDateTime()",
                 ZoneId.class));
         entries.add(mappingEntry(OffsetTime.class, LocalTime.class, null, "$N.toLocalTime()"));
+    }
+
+    private void addUUIDMappings(Collection<Map.Entry<TypeMapping, Conversion>> entries) {
+        entries.add(mappingEntry(
+                String.class,
+                UUID.class,
+                "possible IllegalArgumentException parsing String to UUID",
+                "$T.fromString($N)",
+                UUID.class));
+        entries.add(mappingEntry(UUID.class, String.class, null, "$N.toString()"));
     }
 
     private void addBigNumberMappings(Collection<Map.Entry<TypeMapping, Conversion>> entries) {

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/CoreTypes.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/CoreTypes.java
@@ -18,12 +18,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.ethelred.kiwiproc.processor.types.*;
 import org.jspecify.annotations.Nullable;
-
-import java.util.UUID;
 
 public class CoreTypes {
     public static final ObjectType STRING_TYPE =

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/SqlTypeMappingRegistry.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/SqlTypeMappingRegistry.java
@@ -11,6 +11,8 @@ import org.ethelred.kiwiproc.meta.ColumnMetaData;
 import org.ethelred.kiwiproc.meta.DBType;
 import org.jspecify.annotations.Nullable;
 
+import java.util.UUID;
+
 public class SqlTypeMappingRegistry {
 
     private static final List<SqlTypeMapping> types = List.of(
@@ -71,6 +73,11 @@ public class SqlTypeMappingRegistry {
                     .dbType("timestamptz")
                     .build(),
             new SqlTypeMapping(JDBCType.NULL, void.class, "", true, true, null, null, null),
+            jdbcType(JDBCType.OTHER)
+                    .baseType(UUID.class)
+                    .dbType("uuid")
+                    .accessorSuffix("Object")
+                    .build(),
             jdbcType(JDBCType.OTHER).baseType(Object.class).build()
 
             // TODO fill out types as necessary
@@ -86,7 +93,7 @@ public class SqlTypeMappingRegistry {
     }
 
     private static final Map<JDBCType, SqlTypeMapping> JDBC_TYPE_SQL_TYPE_MAPPING_MAP =
-            types.stream().collect(Collectors.toMap(SqlTypeMapping::jdbcType, t -> t));
+            types.stream().collect(Collectors.toMap(SqlTypeMapping::jdbcType, t -> t, (a, b) -> a));
     private static final Map<String, SqlTypeMapping> DB_TYPE_SQL_TYPE_MAPPING =
             types.stream().filter(t -> t.dbType() != null).collect(Collectors.toMap(SqlTypeMapping::dbType, t -> t));
 

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/SqlTypeMappingRegistry.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/SqlTypeMappingRegistry.java
@@ -6,12 +6,11 @@ import java.sql.JDBCType;
 import java.time.*;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.ethelred.kiwiproc.meta.ColumnMetaData;
 import org.ethelred.kiwiproc.meta.DBType;
 import org.jspecify.annotations.Nullable;
-
-import java.util.UUID;
 
 public class SqlTypeMappingRegistry {
 
@@ -93,17 +92,22 @@ public class SqlTypeMappingRegistry {
     }
 
     private static final Map<JDBCType, SqlTypeMapping> JDBC_TYPE_SQL_TYPE_MAPPING_MAP =
-            types.stream().collect(Collectors.toMap(SqlTypeMapping::jdbcType, t -> t, (a, b) -> a));
+            types.stream().collect(Collectors.toMap(SqlTypeMapping::jdbcType, t -> t, (a, b) -> b));
     private static final Map<String, SqlTypeMapping> DB_TYPE_SQL_TYPE_MAPPING =
             types.stream().filter(t -> t.dbType() != null).collect(Collectors.toMap(SqlTypeMapping::dbType, t -> t));
 
     private static @Nullable SqlTypeMapping lookup(DBType type) {
-        // prefer dbType mapping if present
-        var r = DB_TYPE_SQL_TYPE_MAPPING.get(type.dbType());
-        if (r == null) {
-            r = JDBC_TYPE_SQL_TYPE_MAPPING_MAP.get(type.jdbcType());
+        // Always prefer dbType mapping if present, EXCEPT for parameters.
+        // MySQL reports ALL parameters as JDBCType.OTHER with unreliable dbType names,
+        // so skip dbType lookup for parameters entirely.
+        boolean isParameter = (type instanceof ColumnMetaData cd) && cd.isParameter();
+        if (!isParameter) {
+            var r = DB_TYPE_SQL_TYPE_MAPPING.get(type.dbType());
+            if (r != null) {
+                return r;
+            }
         }
-        return r;
+        return JDBC_TYPE_SQL_TYPE_MAPPING_MAP.get(type.jdbcType());
     }
 
     public static SqlTypeMapping get(ColumnMetaData columnMetaData) {

--- a/processor/src/test/java/org/ethelred/kiwiproc/processor/CoreTypesTest.java
+++ b/processor/src/test/java/org/ethelred/kiwiproc/processor/CoreTypesTest.java
@@ -144,6 +144,14 @@ public class CoreTypesTest {
     static boolean exclude(TypeMapping typeMapping) {
         var source = typeMapping.source();
         var target = typeMapping.target();
+
+        if (source.className().equals("UUID")) {
+            return !target.className().equals("UUID") && !target.className().equals("String");
+        }
+        if (target.className().equals("UUID")) {
+            return !source.className().equals("UUID") && !source.className().equals("String");
+        }
+
         if (source.className().matches("char")) {
             return target.className().matches(".*(Big|Date|Time).*");
         }

--- a/test-any/src/main/java/org/ethelred/kiwiproc/testany/UuidDAO.java
+++ b/test-any/src/main/java/org/ethelred/kiwiproc/testany/UuidDAO.java
@@ -1,0 +1,23 @@
+/* (C) Edward Harman 2025 */
+package org.ethelred.kiwiproc.testany;
+
+import java.util.List;
+import java.util.UUID;
+import org.ethelred.kiwiproc.annotation.DAO;
+import org.ethelred.kiwiproc.annotation.SqlQuery;
+import org.ethelred.kiwiproc.annotation.SqlUpdate;
+import org.jspecify.annotations.Nullable;
+
+@DAO(dataSourceName = "periodic-table")
+public interface UuidDAO {
+    record UuidRow(UUID id, String label) {}
+
+    @SqlUpdate("INSERT INTO test_uuid (id, label) VALUES (:id, :label)")
+    void insert(UUID id, String label);
+
+    @SqlQuery("SELECT id, label FROM test_uuid WHERE id = :id")
+    @Nullable UuidRow findById(UUID id);
+
+    @SqlQuery("SELECT id, label FROM test_uuid ORDER BY label")
+    List<UuidRow> listAll();
+}

--- a/test-any/src/main/resources/periodic/changelogs/periodic_table.sql
+++ b/test-any/src/main/resources/periodic/changelogs/periodic_table.sql
@@ -189,6 +189,12 @@ INSERT INTO public.periodic_table ("AtomicNumber", "Element", "Symbol", "AtomicM
 ALTER TABLE ONLY public.periodic_table
     ADD CONSTRAINT periodic_table_pkey PRIMARY KEY ("AtomicNumber");
 
+--changeset edward3h:2
+
+CREATE TABLE IF NOT EXISTS test_uuid (
+                                         id    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    label VARCHAR(255) NOT NULL
+    );
 --
 -- PostgreSQL database dump complete
 --

--- a/test-any/src/test/java/org/ethelred/kiwiproc/testany/UuidTest.java
+++ b/test-any/src/test/java/org/ethelred/kiwiproc/testany/UuidTest.java
@@ -1,0 +1,63 @@
+/* (C) Edward Harman 2025 */
+package org.ethelred.kiwiproc.testany;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.postgresql.ds.PGSimpleDataSource;
+
+public class UuidTest {
+    static UuidDAO dao = initializeDAO();
+
+    private static UuidDAO initializeDAO() {
+        var propertiesUrl = UuidTest.class.getResource("/application-test.properties");
+        if (propertiesUrl == null) {
+            throw new AssertionError("DB properties not found");
+        }
+        var properties = new Properties();
+        try (var inputStream = propertiesUrl.openStream();
+                var reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
+            properties.load(reader);
+        } catch (IOException e) {
+            throw new AssertionError("Failed to read DB properties file", e);
+        }
+        var dataSource = new PGSimpleDataSource();
+        dataSource.setURL(properties.getProperty("datasources.periodic-table.url"));
+
+        return new $UuidDAO$Provider(dataSource);
+    }
+
+    @Test
+    void insertAndFindByIdReturnsCorrectRow() {
+        var id = UUID.randomUUID();
+        var label = "test-label-" + id;
+        dao.insert(id, label);
+
+        var result = dao.findById(id);
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(id);
+        assertThat(result.label()).isEqualTo(label);
+    }
+
+    @Test
+    void findByIdReturnsNullForUnknownId() {
+        var result = dao.findById(UUID.randomUUID());
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void listAllContainsInsertedRow() {
+        var id = UUID.randomUUID();
+        var label = "list-test-" + id;
+        dao.insert(id, label);
+
+        var all = dao.listAll();
+        assertThat(all).isNotEmpty();
+        assertThat(all.stream().anyMatch(r -> r.id().equals(id))).isTrue();
+    }
+}


### PR DESCRIPTION
Closes #316

## Changes

- `CoreTypes.java`: Added `UUID.class` to `OBJECT_TYPES` so UUID is registered as a supported core type
- `SqlTypeMappingRegistry.java`: Added `uuid` → `UUID` mapping with `dbType("uuid")` so PostgreSQL `uuid` columns are correctly mapped. Fixed duplicate `JDBCType.OTHER` key collision using merge function `(a, b) -> a`
- `CoreTypes.java`: Added `addUUIDMappings()` for String ↔ UUID conversions
- `CoreTypesTest.java`: Updated `exclude()` to correctly filter out invalid UUID type combinations
- `kiwiproc.allium`: Updated supported types comment to include UUID

## Behaviour

For a `uuid` column in PostgreSQL, the generated code will now produce:

// Reading
UUID idRaw = rs.getObject("id", UUID.class);

// Writing  
statement.setObject(1, param1);

Both use the PostgreSQL JDBC driver's native UUID support.