### PR TITLE
Add git pre-commit hook

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,14 @@
 plugins {
 	id("org.ethelred.kiwiproc").apply(false) // needed so the shared service can be used by sibling subprojects
 	id("jacoco-report-aggregation")
+	id("com.github.jakemarsden.git-hooks")
 }
 
 apply(from = "version.gradle.kts")
+
+gitHooks {
+    hooks.set(mapOf("pre-commit" to "build"))
+}
 
 group = "org.ethelred.kiwiproc"
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 repositories {
+    gradlePluginPortal()
     mavenCentral()
 }
 
@@ -14,6 +15,7 @@ java {
 }
 
 dependencies {
+    implementation("com.github.jakemarsden:git-hooks-gradle-plugin:0.0.2")
     implementation("com.diffplug.spotless:spotless-plugin-gradle:8.4.0")
     implementation(libs.vanniktech.maven.publish)
 }


### PR DESCRIPTION
## Summary

- Adds `com.github.jakemarsden:git-hooks-gradle-plugin:0.0.2` to the buildSrc classpath (with `gradlePluginPortal()` repository)
- Applies the plugin at the root project level and configures it to run `./gradlew build` on `pre-commit`
- Installs `.git/hooks/pre-commit` automatically whenever any Gradle task is run

The plugin is applied at the root project rather than in the `java-convention` subproject convention to avoid the plugin creating spurious `.git/` directories inside each subproject folder.

## Test plan

- [ ] Run `./gradlew help` and confirm `.git/hooks/pre-commit` exists containing `./gradlew build`
- [ ] Attempt a commit and verify the build runs before the commit is accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)