### PR TITLE
Update README: fix database support, add features and docs link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -14,6 +14,18 @@ Inspired by:
 * https://micronaut-projects.github.io/micronaut-data/latest/guide/#dbc[micronaut-data-jdbc]
 * https://github.com/cashapp/sqldelight[SQL Delight]
 
+== Features
+
+* Type-safe SQL queries validated at compile time via annotation processing
+* PostgreSQL, H2, and MySQL support
+* Spring and Micronaut integration
+
+== Documentation
+
+Full documentation: https://edward3h.github.io/kiwiproc/
+
 == Databases
 
-For now, _only_ Postgresql is supported. It's an "MVP".
+PostgreSQL is fully supported. H2 and MySQL are also supported with some limitations.
+
+See the https://edward3h.github.io/kiwiproc/#_database_support[Database Support] section of the documentation for details.


### PR DESCRIPTION
## Summary

* Corrects the outdated claim that only PostgreSQL is supported — H2 and MySQL are now also supported
* Adds a Features section listing key capabilities
* Adds a Documentation section linking to the full docs site at https://edward3h.github.io/kiwiproc/
* Updates the Databases section to accurately describe all three supported databases

## Test plan

- [x] `./gradlew build` passes (pre-commit hook verified)
- [ ] Review rendered AsciiDoc on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)