### PR TITLE
docs: tabbed Groovy/Kotlin code blocks

### DIFF
--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -10,17 +10,10 @@ repositories {
     mavenCentral()
 }
 
-//configurations.create("asciidoctorExtensions")
-
-dependencies {
-//    add("asciidoctorExtensions","com.bmuschko:asciidoctorj-tabbed-code-extension:0.3")
-}
-
 tasks.named<AsciidoctorTask>("asciidoctor").configure {
     dependsOn(conversionsTable)
     inputs.files("src/docs/asciidoc")
     baseDirFollowsSourceDir()
-//    configurations("asciidoctorExtensions")
     attributes(
         mapOf(
             "build-dir" to layout.buildDirectory.get().toString(),

--- a/docs/src/docs/asciidoc/docinfo.html
+++ b/docs/src/docs/asciidoc/docinfo.html
@@ -4,4 +4,112 @@
      .subheader, .admonitionblock td.content>.title, .audioblock>.title, .exampleblock>.title, .imageblock>.title, .listingblock>.title, .literalblock>.title, .stemblock>.title, .openblock>.title, .paragraph>.title, .quoteblock>.title, table.tableblock>.title, .verseblock>.title, .videoblock>.title, .dlist>.title, .olist>.title, .ulist>.title, .qlist>.title, .hdlist>.title{
         color: #4c8a13;
     }
+
+    .tabbed-block {
+        margin-bottom: 1.25em;
+    }
+    .tab-bar {
+        display: flex;
+        border-bottom: 2px solid #ddd;
+        margin-bottom: 0;
+    }
+    .tab-button {
+        background: none;
+        border: none;
+        border-bottom: 3px solid transparent;
+        margin-bottom: -2px;
+        padding: 0.4em 1em;
+        cursor: pointer;
+        font-family: "Open Sans","DejaVu Sans",sans-serif;
+        font-size: 0.875em;
+        color: rgba(0,0,0,0.6);
+    }
+    .tab-button:hover {
+        color: #4c8a13;
+    }
+    .tab-button.active {
+        color: #4c8a13;
+        border-bottom-color: #4c8a13;
+        font-weight: 600;
+    }
+    .tab-panel {
+        display: none;
+    }
+    .tab-panel.active {
+        display: block;
+    }
+    .tabbed-block .listingblock,
+    .tabbed-block .colist {
+        margin-bottom: 0;
+    }
 </style>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    var blocks = Array.from(document.querySelectorAll('.listingblock.primary, .listingblock.secondary'));
+    if (!blocks.length) return;
+
+    function nextColist(el) {
+        var sib = el.nextElementSibling;
+        return sib && sib.classList.contains('colist') ? sib : null;
+    }
+
+    // Group consecutive primary/secondary blocks, skipping over any colist between them
+    var groups = [];
+    var i = 0;
+    while (i < blocks.length) {
+        var group = [blocks[i]];
+        while (true) {
+            var last = group[group.length - 1];
+            var colist = nextColist(last);
+            var candidate = (colist || last).nextElementSibling;
+            var next = blocks[i + group.length];
+            if (next && candidate === next) {
+                group.push(next);
+            } else {
+                break;
+            }
+        }
+        groups.push(group);
+        i += group.length;
+    }
+
+    groups.forEach(function (group) {
+        if (group.length < 2) return;
+
+        var parent = group[0].parentNode;
+        var container = document.createElement('div');
+        container.className = 'tabbed-block';
+        var tabBar = document.createElement('div');
+        tabBar.className = 'tab-bar';
+        container.appendChild(tabBar);
+        parent.insertBefore(container, group[0]);
+
+        group.forEach(function (block) {
+            var isPrimary = block.classList.contains('primary');
+            var titleEl = block.querySelector(':scope > .title');
+            var label = titleEl ? titleEl.textContent.trim() : (isPrimary ? 'Kotlin' : 'Groovy');
+            if (titleEl) titleEl.remove();
+
+            var colist = nextColist(block);
+
+            var panel = document.createElement('div');
+            panel.className = 'tab-panel' + (isPrimary ? ' active' : '');
+            container.appendChild(panel);
+            panel.appendChild(block);
+            if (colist) panel.appendChild(colist);
+
+            var tab = document.createElement('button');
+            tab.className = 'tab-button' + (isPrimary ? ' active' : '');
+            tab.textContent = label;
+            tabBar.appendChild(tab);
+
+            tab.addEventListener('click', function () {
+                container.querySelectorAll('.tab-panel').forEach(function (p) { p.classList.remove('active'); });
+                container.querySelectorAll('.tab-button').forEach(function (t) { t.classList.remove('active'); });
+                panel.classList.add('active');
+                tab.classList.add('active');
+            });
+        });
+    });
+});
+</script>

--- a/docs/src/docs/asciidoc/docinfo.html
+++ b/docs/src/docs/asciidoc/docinfo.html
@@ -48,6 +48,24 @@ document.addEventListener('DOMContentLoaded', function () {
     var blocks = Array.from(document.querySelectorAll('.listingblock.primary, .listingblock.secondary'));
     if (!blocks.length) return;
 
+    function activateLabel(label) {
+        document.querySelectorAll('.tabbed-block').forEach(function (container) {
+            var matched = false;
+            container.querySelectorAll('.tab-button').forEach(function (btn) {
+                if (btn.textContent === label) matched = true;
+            });
+            if (!matched) return;
+            container.querySelectorAll('.tab-panel').forEach(function (p) { p.classList.remove('active'); });
+            container.querySelectorAll('.tab-button').forEach(function (btn) {
+                btn.classList.remove('active');
+                if (btn.textContent === label) {
+                    btn.classList.add('active');
+                    btn.closest('.tabbed-block').querySelectorAll('.tab-panel')[Array.from(btn.parentNode.children).indexOf(btn)].classList.add('active');
+                }
+            });
+        });
+    }
+
     function nextColist(el) {
         var sib = el.nextElementSibling;
         return sib && sib.classList.contains('colist') ? sib : null;
@@ -63,7 +81,7 @@ document.addEventListener('DOMContentLoaded', function () {
             var colist = nextColist(last);
             var candidate = (colist || last).nextElementSibling;
             var next = blocks[i + group.length];
-            if (next && candidate === next) {
+            if (next && candidate === next && !last.classList.contains('primary')) {
                 group.push(next);
             } else {
                 break;
@@ -104,12 +122,14 @@ document.addEventListener('DOMContentLoaded', function () {
             tabBar.appendChild(tab);
 
             tab.addEventListener('click', function () {
-                container.querySelectorAll('.tab-panel').forEach(function (p) { p.classList.remove('active'); });
-                container.querySelectorAll('.tab-button').forEach(function (t) { t.classList.remove('active'); });
-                panel.classList.add('active');
-                tab.classList.add('active');
+                var label = tab.textContent;
+                localStorage.setItem('kiwiproc-tab', label);
+                activateLabel(label);
             });
         });
     });
+
+    var saved = localStorage.getItem('kiwiproc-tab');
+    if (saved) activateLabel(saved);
 });
 </script>

--- a/docs/src/docs/asciidoc/gradle_plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle_plugin.adoc
@@ -2,7 +2,16 @@
 
 As noted in Quick Start, add the plugin with
 
+[source,groovy,indent=0,subs="verbatim,attributes",role="secondary"]
+.Groovy
+----
+plugins {
+    id 'org.ethelred.kiwiproc' version '{revnumber}'
+}
+----
+
 [source,kotlin,indent=0,subs="verbatim,attributes",role="primary"]
+.Kotlin
 ----
 plugins {
     id("org.ethelred.kiwiproc").version("{revnumber}")
@@ -15,8 +24,23 @@ With no additional configuration, this will assume:
 * A Liquibase changelog in "src/main/resources/changelog.xml".
 * Use `jakarta.inject` annotations in generated code.
 
+All available properties with their default values:
+
+[source,groovy,indent=0,subs="verbatim,attributes",role="secondary"]
+.Groovy
+----
+import org.ethelred.kiwiproc.processorconfig.DependencyInjectionStyle
+
+kiwiProc {
+    dependencyInjectionStyle = DependencyInjectionStyle.JAKARTA // <1>
+    debug = false // <2>
+    addDependencies = true // <3>
+    liquibaseChangelog = file("$projectDir/src/main/resources/changelog.xml") // <4>
+}
+----
+
 [source,kotlin,indent=0,subs="verbatim,attributes",role="primary"]
-.Properties shown with their default values
+.Kotlin
 ----
 import org.ethelred.kiwiproc.processorconfig.DependencyInjectionStyle
 
@@ -42,7 +66,21 @@ Therefore, a Liquibase changelog file is _required_, except when using an extern
 To use embedded H2 instead of PostgreSQL, set `driverClassName` to the H2 driver class name.
 H2 is a pure-Java in-memory database — no Docker required.
 
+[source,groovy,indent=0,subs="verbatim,attributes",role="secondary"]
+.Groovy
+----
+kiwiProc {
+    dataSources {
+        register("default") {
+            driverClassName = "org.h2.Driver" // <1>
+            liquibaseChangelog = file("$projectDir/src/main/resources/changelog.xml")
+        }
+    }
+}
+----
+
 [source,kotlin,indent=0,subs="verbatim,attributes",role="primary"]
+.Kotlin
 ----
 kiwiProc {
     dataSources {
@@ -62,7 +100,21 @@ See xref:databases.adoc#h2-limitations[H2 Limitations] for a list of features no
 To use embedded MySQL instead of PostgreSQL, set `driverClassName` to the MySQL driver class name.
 This requires Docker to be available on the build machine (Testcontainers is used internally).
 
+[source,groovy,indent=0,subs="verbatim,attributes",role="secondary"]
+.Groovy
+----
+kiwiProc {
+    dataSources {
+        register("default") {
+            driverClassName = "com.mysql.cj.jdbc.Driver" // <1>
+            liquibaseChangelog = file("$projectDir/src/main/resources/changelog.xml")
+        }
+    }
+}
+----
+
 [source,kotlin,indent=0,subs="verbatim,attributes",role="primary"]
+.Kotlin
 ----
 kiwiProc {
     dataSources {
@@ -90,7 +142,38 @@ interface FirstDatabaseDAO {
 ----
 <1> Specify the datasource name in an interface.
 
+[source,groovy,indent=0,subs="verbatim,attributes",role="secondary"]
+.Groovy
+----
+kiwiProc {
+    dataSources {
+        register("firstDatabase") { // <1>
+            liquibaseChangelog = file("$projectDir/src/main/resources/first/changelog.xml")
+        }
+        register("secondDatabase") {
+            liquibaseChangelog = file("$projectDir/src/main/resources/somepath/changelog.xml")
+        }
+        register("externalDatabase") { // <2>
+            jdbcUrl = "jdbc:postgresql://db.example.com/database"
+            // optional
+            database = "..."
+            username = "..."
+            password = "..." // <3>
+        }
+        register("externalMySQL") { // <4>
+            jdbcUrl = "jdbc:mysql://db.example.com/database"
+            username = "..."
+            password = "..."
+        }
+        register("externalH2") { // <5>
+            jdbcUrl = "jdbc:h2:file:/path/to/database"
+        }
+    }
+}
+----
+
 [source,kotlin,indent=0,subs="verbatim,attributes",role="primary"]
+.Kotlin
 ----
 kiwiProc {
     dataSources {
@@ -124,7 +207,20 @@ kiwiProc {
 <4> An external MySQL datasource uses a `jdbc:mysql://` URL.
 <5> An external H2 datasource uses a `jdbc:h2:` URL.
 
+[source,groovy,indent=0,subs="verbatim,attributes",role="secondary"]
+.Groovy
+----
+kiwiProc {
+    dataSources {
+        register("default") { // <1>
+            jdbcUrl = "jdbc:postgresql://db.example.com/database"
+        }
+    }
+}
+----
+
 [source,kotlin,indent=0,subs="verbatim,attributes",role="primary"]
+.Kotlin
 ----
 kiwiProc {
     dataSources {

--- a/docs/src/docs/asciidoc/quick_start.adoc
+++ b/docs/src/docs/asciidoc/quick_start.adoc
@@ -18,7 +18,7 @@ Add the Gradle plugin. By default, it will:
 .Groovy
 ----
 plugins {
-    id("org.ethelred.kiwiproc").version("{revnumber}")
+    id 'org.ethelred.kiwiproc' version '{revnumber}'
 }
 
 dependencies {


### PR DESCRIPTION
## Summary

- Adds a tabbed view for Groovy/Kotlin Gradle DSL snippets in the docs, replacing the current stacked layout
- Implemented via custom CSS + vanilla JS in `docinfo.html` (no external AsciidoctorJ extension required)
- `gradle_plugin.adoc` gains Groovy secondary tabs for all six Kotlin blocks
- `quick_start.adoc` Groovy plugin syntax updated to idiomatic form (`id 'foo' version 'bar'`)
- Clicking a tab syncs all tab groups on the page to that language
- Preference is persisted to `localStorage` and restored on return visits

## Test plan

- [ ] Open `docs/build/docs/asciidoc/index.html` locally after `./gradlew :docs:asciidoctor`
- [ ] Verify Groovy/Kotlin tabs appear throughout the Gradle Plugin section
- [ ] Click "Groovy" — all groups on the page should switch
- [ ] Reload the page — Groovy should still be selected
- [ ] Check the Multiple and External Datasources section has two separate tab groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)