### PR TITLE
feat: enum type conversion support (#80)

### DIFF
--- a/docs/src/docs/asciidoc/types.adoc
+++ b/docs/src/docs/asciidoc/types.adoc
@@ -19,7 +19,7 @@ These are generalized types, not Java or SQL types.
 |V |void
 |I |int or a compatible type
 |P |A primitive or boxed primitive
-|O |Object type. Specifically, one of: String, BigInteger, BigDecimal, LocalDate, LocalTime, OffsetTime, LocalDateTime, OffsetDateTime, UUID
+|O |Object type. Specifically, one of: String, BigInteger, BigDecimal, LocalDate, LocalTime, OffsetTime, LocalDateTime, OffsetDateTime, UUID, or any Java `enum`
 |S | P \| O
 |?S |@Nullable (specifically org.jspecify.annotations.Nullable), or Optional<S>. A boxed primitive is also treated as nullable when it is not a type parameter of a container. Optional is only accepted as the return type of a query method.
 |SC<S> | A Collection or array, _only_ in a context where it is mapped to or from a SQL array.
@@ -85,3 +85,13 @@ Kiwiproc has a set of type conversions, for any supported types where it makes s
 include::{build-dir}/conversions.adoc[]
 
 (Any type can be converted to String.)
+
+==== Enum conversions
+
+Java `enum` types are converted to and from SQL using the constant name:
+
+* *SQL → Java*: `MyEnum.valueOf(stringValue)` — mapped from a `VARCHAR` or PostgreSQL native enum column.
+A compile-time warning is emitted because an unrecognised DB value will throw `IllegalArgumentException` at runtime.
+* *Java → SQL*: `myEnum.name()` — the string name is bound as a parameter using `setObject` with `Types.OTHER`, which PostgreSQL accepts for both `VARCHAR` and native enum columns.
+
+PostgreSQL native enum columns (`CREATE TYPE … AS ENUM (…)`) are supported transparently: the JDBC driver returns their values as `String`, so no special handling is required on the read path.

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/Conversion.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/Conversion.java
@@ -5,6 +5,8 @@ import org.jspecify.annotations.Nullable;
 
 public sealed interface Conversion
         permits AssignmentConversion,
+                EnumFromStringConversion,
+                EnumToStringConversion,
                 FromSqlArrayConversion,
                 InvalidConversion,
                 NullableSourceConversion,

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/CoreTypes.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/CoreTypes.java
@@ -292,6 +292,20 @@ public class CoreTypes {
         if (source.equals(target) || source.withIsNullable(true).equals(target)) {
             return new AssignmentConversion();
         }
+        if (target instanceof EnumType enumType && STRING_TYPE.equals(source.withIsNullable(false))) {
+            Conversion result = new EnumFromStringConversion(enumType);
+            if (source.isNullable()) {
+                result = new NullableSourceConversion(result);
+            }
+            return result;
+        }
+        if (source instanceof EnumType && STRING_TYPE.equals(target.withIsNullable(false))) {
+            Conversion result = new EnumToStringConversion();
+            if (source.isNullable()) {
+                result = new NullableSourceConversion(result);
+            }
+            return result;
+        }
         if (source instanceof CollectionType ct && target instanceof SqlArrayType sat) {
             return toSqlArray(ct, sat);
         }

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/DAOParameterInfo.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/DAOParameterInfo.java
@@ -2,6 +2,7 @@
 package org.ethelred.kiwiproc.processor;
 
 import java.sql.JDBCType;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -30,19 +31,28 @@ public record DAOParameterInfo(
             if (!conversion.isValid() && columnMetaData.jdbcType() == JDBCType.OTHER) {
                 conversion = new AssignmentConversion();
             }
+            // Enum parameters must use setObject(index, value, Types.OTHER) so PostgreSQL
+            // accepts both VARCHAR-backed and native enum columns without a type mismatch.
+            var sqlType = columnMetaData.jdbcType().getVendorTypeNumber();
+            if (innerConversion(conversion) instanceof EnumToStringConversion) {
+                setter = "setObject";
+                sqlType = Types.OTHER;
+            }
             result.add(new DAOParameterInfo(
-                    columnMetaData.index(),
-                    methodParameterInfo,
-                    setter,
-                    columnMetaData.jdbcType().getVendorTypeNumber(),
-                    mapper,
-                    conversion));
+                    columnMetaData.index(), methodParameterInfo, setter, sqlType, mapper, conversion));
         }));
         return result;
     }
 
     public String javaAccessorSuffix() {
         return source.isRecordComponent() ? ".%s()".formatted(source.name().name()) : "";
+    }
+
+    private static Conversion innerConversion(Conversion conversion) {
+        if (conversion instanceof NullableSourceConversion nsc) {
+            return nsc.conversion();
+        }
+        return conversion;
     }
 
     @Override

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/EnumFromStringConversion.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/EnumFromStringConversion.java
@@ -1,0 +1,22 @@
+/* (C) Edward Harman 2024 */
+package org.ethelred.kiwiproc.processor;
+
+import org.ethelred.kiwiproc.processor.types.EnumType;
+
+public record EnumFromStringConversion(EnumType enumType) implements Conversion {
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
+    @Override
+    public boolean hasWarning() {
+        return true;
+    }
+
+    @Override
+    public String warning() {
+        return "possible IllegalArgumentException if value doesn't match any %s constant"
+                .formatted(enumType.className());
+    }
+}

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/EnumToStringConversion.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/EnumToStringConversion.java
@@ -1,0 +1,21 @@
+/* (C) Edward Harman 2024 */
+package org.ethelred.kiwiproc.processor;
+
+import org.jspecify.annotations.Nullable;
+
+public record EnumToStringConversion() implements Conversion {
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
+    @Override
+    public boolean hasWarning() {
+        return false;
+    }
+
+    @Override
+    public @Nullable String warning() {
+        return null;
+    }
+}

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/SqlTypeMappingRegistry.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/SqlTypeMappingRegistry.java
@@ -6,6 +6,7 @@ import java.sql.JDBCType;
 import java.time.*;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.ethelred.kiwiproc.meta.ColumnMetaData;
@@ -114,6 +115,13 @@ public class SqlTypeMappingRegistry {
         var r = lookup(columnMetaData);
         if (r == null) {
             throw new IllegalArgumentException("Unsupported JDBCType type " + columnMetaData.jdbcType());
+        }
+        // PostgreSQL native enum result columns: JDBC reports OTHER, driver returns java.lang.String.
+        // Treat them as VARCHAR (String) so getString() and subsequent enum conversion work.
+        if (!columnMetaData.isParameter()
+                && Object.class.equals(r.baseType())
+                && "java.lang.String".equals(columnMetaData.dbClassName())) {
+            r = Objects.requireNonNull(JDBC_TYPE_SQL_TYPE_MAPPING_MAP.get(JDBCType.VARCHAR));
         }
         if (r.jdbcType() == JDBCType.ARRAY) {
             if (columnMetaData.componentType() == null) {

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/generator/InstanceGenerator.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/generator/InstanceGenerator.java
@@ -298,12 +298,23 @@ public class InstanceGenerator {
                         .addStatement("statement.setNull($L, $L)", parameterInfo.index(), parameterInfo.sqlType())
                         .nextControlFlow("else");
             }
-            builder.addStatement("statement.$L($L, $L)", parameterInfo.setter(), parameterInfo.index(), name);
+            if ("setObject".equals(parameterInfo.setter()) && isEnumConversion(parameterInfo.conversion())) {
+                builder.addStatement(
+                        "statement.setObject($L, $L, $L)", parameterInfo.index(), name, parameterInfo.sqlType());
+            } else {
+                builder.addStatement("statement.$L($L, $L)", parameterInfo.setter(), parameterInfo.index(), name);
+            }
             if (nullableSource) {
                 builder.endControlFlow();
             }
             parameterNames.add(accessor);
         });
+    }
+
+    private static boolean isEnumConversion(Conversion conversion) {
+        if (conversion instanceof EnumToStringConversion) return true;
+        if (conversion instanceof NullableSourceConversion nsc) return isEnumConversion(nsc.conversion());
+        return false;
     }
 
     private void buildConversion(
@@ -442,6 +453,12 @@ public class InstanceGenerator {
                         .beginControlFlow("if ($L != null)", accessor);
                 buildConversion(builder, methodInfo, nsc.conversion(), targetType, assignee, accessor, false);
                 builder.endControlFlow();
+            } else if (conversion instanceof EnumFromStringConversion efsc) {
+                var enumClass = ClassName.get(
+                        efsc.enumType().packageName(), efsc.enumType().className());
+                builder.addStatement("$L$L = $T.valueOf($L)", insertVar, assignee, enumClass, accessor);
+            } else if (conversion instanceof EnumToStringConversion) {
+                builder.addStatement("$L$L = $L.name()", insertVar, assignee, accessor);
             } else {
                 logger.error(methodInfo.get(), "Unsupported Conversion %s".formatted(conversion));
             }

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/generator/InstanceGenerator.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/generator/InstanceGenerator.java
@@ -312,8 +312,12 @@ public class InstanceGenerator {
     }
 
     private static boolean isEnumConversion(Conversion conversion) {
-        if (conversion instanceof EnumToStringConversion) return true;
-        if (conversion instanceof NullableSourceConversion nsc) return isEnumConversion(nsc.conversion());
+        if (conversion instanceof EnumToStringConversion) {
+            return true;
+        }
+        if (conversion instanceof NullableSourceConversion nsc) {
+            return isEnumConversion(nsc.conversion());
+        }
         return false;
     }
 

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/types/EnumType.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/types/EnumType.java
@@ -1,0 +1,19 @@
+/* (C) Edward Harman 2024 */
+package org.ethelred.kiwiproc.processor.types;
+
+public record EnumType(String packageName, String className, boolean isNullable) implements KiwiType {
+    @Override
+    public String toString() {
+        return className + "(enum)" + (isNullable ? "/nullable" : "/non-null");
+    }
+
+    @Override
+    public EnumType withIsNullable(boolean newValue) {
+        return new EnumType(packageName, className, newValue);
+    }
+
+    @Override
+    public boolean isSimple() {
+        return true;
+    }
+}

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/types/EnumTypeHandler.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/types/EnumTypeHandler.java
@@ -1,0 +1,22 @@
+/* (C) Edward Harman 2024 */
+package org.ethelred.kiwiproc.processor.types;
+
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+
+class EnumTypeHandler extends DeclaredTypeHandler {
+    EnumTypeHandler(KiwiTypeVisitor visitor, TypeUtils utils) {
+        super(visitor, utils);
+    }
+
+    @Override
+    public KiwiType apply(DeclaredType t) {
+        return new EnumType(utils.packageName(t), utils.className(t), utils.isNullable(t));
+    }
+
+    @Override
+    public boolean test(DeclaredType t) {
+        return ((TypeElement) t.asElement()).getKind() == ElementKind.ENUM;
+    }
+}

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/types/KiwiType.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/types/KiwiType.java
@@ -8,6 +8,7 @@ import org.ethelred.kiwiproc.processor.RowCount;
  */
 public sealed interface KiwiType
         permits CollectionType,
+                EnumType,
                 MapType,
                 ObjectType,
                 OptionalType,

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/types/KiwiTypeVisitor.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/types/KiwiTypeVisitor.java
@@ -14,6 +14,7 @@ public class KiwiTypeVisitor extends SimpleTypeVisitor14<KiwiType, Void> {
         collectionTypeHandler = new CollectionTypeHandler(this, utils);
         declaredTypeHandlers = List.of(
                 new BoxedTypeHandler(this, utils),
+                new EnumTypeHandler(this, utils),
                 new ObjectTypeHandler(this, utils),
                 collectionTypeHandler,
                 new MapTypeHandler(this, utils),

--- a/processor/src/test/java/org/ethelred/kiwiproc/processor/CoreTypesTest.java
+++ b/processor/src/test/java/org/ethelred/kiwiproc/processor/CoreTypesTest.java
@@ -101,7 +101,10 @@ public class CoreTypesTest {
                         true,
                         false,
                         "fail"),
-                arguments(ofClass(int.class), ofClass(boolean.class), true, false, "value != 0"));
+                arguments(ofClass(int.class), ofClass(boolean.class), true, false, "value != 0"),
+                // enum conversions
+                arguments(ofClass(String.class), new EnumType("com.example", "TestEnum", false), true, true, "fail"),
+                arguments(new EnumType("com.example", "TestEnum", false), ofClass(String.class), true, false, "fail"));
     }
 
     @ParameterizedTest

--- a/processor/src/test/java/org/ethelred/kiwiproc/processor/ProcessorTest.java
+++ b/processor/src/test/java/org/ethelred/kiwiproc/processor/ProcessorTest.java
@@ -349,6 +349,22 @@ public class ProcessorTest {
                                 "A SqlQuery with Map return type fails without key_column or 'key' column in SQL.")
                         .withExpectedErrorMessage("Invalid return type")
                         .withExpectedErrorCount(2),
+                // enum conversions
+                method("""
+                        enum ChainType { FAST_FOOD, FINE_DINING }
+                        @SqlUpdate(sql = "UPDATE restaurant SET chain = :chain WHERE name = :name")
+                        void updateChain(String name, ChainType chain);
+                        """)
+                        .withDisplayName("A SqlUpdate with enum parameter against VARCHAR column compiles.")
+                        .succeeds(),
+                method("""
+                        enum ChainType { FAST_FOOD, FINE_DINING }
+                        @SqlQuery(sql = "SELECT chain FROM restaurant WHERE name = :name")
+                        @org.jspecify.annotations.Nullable ChainType getChain(String name);
+                        """)
+                        .withDisplayName(
+                                "A SqlQuery returning a nullable enum type from a nullable VARCHAR column compiles.")
+                        .succeeds(),
                 // Spec gap: non-record parameter not matched to any placeholder — processor does not yet enforce this
                 method("""
                         @SqlQuery(sql = "SELECT name FROM restaurant WHERE name = :name")

--- a/test-any/build.gradle.kts
+++ b/test-any/build.gradle.kts
@@ -18,6 +18,9 @@ kiwiProc {
         register("datetime") {
             liquibaseChangelog = file("$projectDir/src/main/resources/datetime/changelog.xml")
         }
+        register("enum") {
+            liquibaseChangelog = file("$projectDir/src/main/resources/enum/changelog.xml")
+        }
         if (project.hasProperty("kiwiproc.periodic-table.url")) {
             register("periodic-table") {
                 jdbcUrl = project.property("kiwiproc.periodic-table.url").toString()

--- a/test-any/src/main/java/org/ethelred/kiwiproc/testany/AnimalDAO.java
+++ b/test-any/src/main/java/org/ethelred/kiwiproc/testany/AnimalDAO.java
@@ -1,0 +1,23 @@
+/* (C) Edward Harman 2024 */
+package org.ethelred.kiwiproc.testany;
+
+import java.util.List;
+import org.ethelred.kiwiproc.annotation.DAO;
+import org.ethelred.kiwiproc.annotation.SqlQuery;
+import org.ethelred.kiwiproc.annotation.SqlUpdate;
+import org.jspecify.annotations.Nullable;
+
+@DAO(dataSourceName = "enum")
+public interface AnimalDAO {
+    record AnimalRow(
+            int id, String name, AnimalKind kind, @Nullable AnimalTag tag) {}
+
+    @SqlUpdate("INSERT INTO test_animal (name, kind, tag) VALUES (:name, :kind, :tag)")
+    void insert(String name, AnimalKind kind, @Nullable AnimalTag tag);
+
+    @SqlQuery("SELECT id, name, kind, tag FROM test_animal WHERE id = :id")
+    @Nullable AnimalRow findById(int id);
+
+    @SqlQuery("SELECT id, name, kind, tag FROM test_animal ORDER BY id")
+    List<AnimalRow> listAll();
+}

--- a/test-any/src/main/java/org/ethelred/kiwiproc/testany/AnimalKind.java
+++ b/test-any/src/main/java/org/ethelred/kiwiproc/testany/AnimalKind.java
@@ -1,0 +1,8 @@
+/* (C) Edward Harman 2024 */
+package org.ethelred.kiwiproc.testany;
+
+public enum AnimalKind {
+    CAT,
+    DOG,
+    BIRD
+}

--- a/test-any/src/main/java/org/ethelred/kiwiproc/testany/AnimalTag.java
+++ b/test-any/src/main/java/org/ethelred/kiwiproc/testany/AnimalTag.java
@@ -1,0 +1,7 @@
+/* (C) Edward Harman 2024 */
+package org.ethelred.kiwiproc.testany;
+
+public enum AnimalTag {
+    INDOOR,
+    OUTDOOR
+}

--- a/test-any/src/main/resources/enum/changelog.xml
+++ b/test-any/src/main/resources/enum/changelog.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+   <includeAll path="changelogs/" relativeToChangelogFile="true"/>
+</databaseChangeLog>

--- a/test-any/src/main/resources/enum/changelogs/01_schema.sql
+++ b/test-any/src/main/resources/enum/changelogs/01_schema.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+
+--changeset edward3h:enum-1
+CREATE TYPE animal_kind AS ENUM ('CAT', 'DOG', 'BIRD');
+
+CREATE TABLE test_animal (
+    id   SERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    kind animal_kind  NOT NULL,
+    tag  VARCHAR(50)
+);

--- a/test-any/src/test/java/org/ethelred/kiwiproc/testany/AnimalTest.java
+++ b/test-any/src/test/java/org/ethelred/kiwiproc/testany/AnimalTest.java
@@ -1,0 +1,62 @@
+/* (C) Edward Harman 2024 */
+package org.ethelred.kiwiproc.testany;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.postgresql.ds.PGSimpleDataSource;
+
+public class AnimalTest {
+    static AnimalDAO dao = initializeDAO();
+
+    private static AnimalDAO initializeDAO() {
+        var propertiesUrl = AnimalTest.class.getResource("/application-test.properties");
+        if (propertiesUrl == null) {
+            throw new AssertionError("DB properties not found");
+        }
+        var properties = new Properties();
+        try (var inputStream = propertiesUrl.openStream();
+                var reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
+            properties.load(reader);
+        } catch (IOException e) {
+            throw new AssertionError("Failed to read DB properties file", e);
+        }
+        var dataSource = new PGSimpleDataSource();
+        dataSource.setURL(properties.getProperty("datasources.enum.url"));
+        return new $AnimalDAO$Provider(dataSource);
+    }
+
+    @Test
+    void insertAndFindByIdReturnsCorrectRow() {
+        dao.insert("Whiskers", AnimalKind.CAT, AnimalTag.INDOOR);
+
+        var all = dao.listAll();
+        assertThat(all).isNotEmpty();
+        var row = all.stream()
+                .filter(r -> r.name().equals("Whiskers"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(row.kind()).isEqualTo(AnimalKind.CAT);
+        assertThat(row.tag()).isEqualTo(AnimalTag.INDOOR);
+    }
+
+    @Test
+    void insertWithNullTagAndFindById() {
+        dao.insert("Rex", AnimalKind.DOG, null);
+
+        var all = dao.listAll();
+        var row = all.stream().filter(r -> r.name().equals("Rex")).findFirst().orElseThrow();
+        assertThat(row.kind()).isEqualTo(AnimalKind.DOG);
+        assertThat(row.tag()).isNull();
+    }
+
+    @Test
+    void findByIdReturnsNullForUnknownId() {
+        var result = dao.findById(Integer.MAX_VALUE);
+        assertThat(result).isNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Java enum types can now be used as `@DAO` method parameters and return types
- Enums are mapped to/from SQL via name string: `MyEnum.valueOf(str)` / `myEnum.name()`
- PostgreSQL native enum columns (`CREATE TYPE … AS ENUM`) are supported transparently alongside VARCHAR-backed enums
- Compile-time warning generated when reading: *possible IllegalArgumentException if value doesn't match any constant*

## Design

**Type detection:** new `EnumType` (sealed `KiwiType`) and `EnumTypeHandler` (checks `ElementKind.ENUM`) added to the visitor chain before `ObjectTypeHandler`.

**Conversions:** `EnumFromStringConversion` (String→enum, carries warning) and `EnumToStringConversion` (enum→String) added to the `Conversion` sealed hierarchy. `CoreTypes.lookup()` returns these when source/target is an `EnumType` against a String type.

**PostgreSQL native enums:** `SqlTypeMappingRegistry.get()` remaps result columns with `JDBCType.OTHER + dbClassName=java.lang.String` to the VARCHAR/String mapping, so `getString()` works for reading.

**INSERT parameters:** `DAOParameterInfo` detects enum-to-string conversions and sets `setter="setObject"`, `sqlType=Types.OTHER`. `InstanceGenerator.addParameters()` emits `statement.setObject(idx, val, 1111)` only for enum parameters, leaving MySQL's generic Object parameters using the 2-arg form (fixes a regression I caught during development).

## Test plan

- [x] `CoreTypesTest.testConversions` — String→EnumType (warning, valid) and EnumType→String (no warning, valid)
- [x] `ProcessorTest.testMethods` — SqlUpdate with enum param and SqlQuery returning nullable enum both compile
- [x] `AnimalTest` (test-any) — end-to-end: PG native enum column (`animal_kind`) + VARCHAR-backed nullable enum (`tag`); insert/find/listAll; null tag case
- [x] Full build `./gradlew build` — 114 tasks, 0 failures (including MySQL which now passes again)

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)