### PR TITLE
feat: enforce braces via Checkstyle NeedBraces rule

### DIFF
--- a/buildSrc/src/main/kotlin/java-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-convention.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     `java-library`
     jacoco
+    checkstyle
     id("com.diffplug.spotless")
 }
 
@@ -34,6 +35,10 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
     testImplementation("com.google.truth:truth:1.4.5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+checkstyle {
+    configFile = rootProject.file("config/checkstyle/checkstyle.xml")
 }
 
 spotless {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <property name="severity" value="error"/>
+    <module name="TreeWalker">
+        <module name="NeedBraces"/>
+    </module>
+</module>

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     `java-gradle-plugin`
     jacoco
+    checkstyle
     id("com.gradle.plugin-publish") version "2.1.1"
     id("com.diffplug.spotless").version("8.6.0")
     id("signing")
@@ -96,6 +97,10 @@ tasks.named<JacocoReport>("jacocoTestReport") {
 tasks.named<ProcessResources>("processResources") {
     inputs.property("version", project.version)
     expand("version" to project.version)
+}
+
+checkstyle {
+    configFile = file("../../config/checkstyle/checkstyle.xml")
 }
 
 spotless {

--- a/querymeta/src/main/java/org/ethelred/kiwiproc/meta/SqlName.java
+++ b/querymeta/src/main/java/org/ethelred/kiwiproc/meta/SqlName.java
@@ -21,8 +21,12 @@ public record SqlName(String name) {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         SqlName sqlName = (SqlName) o;
         return name.equalsIgnoreCase(sqlName.name);
     }


### PR DESCRIPTION
## Summary

- Adds the Checkstyle `NeedBraces` rule to the build via both the `java-convention` plugin (covers all modules) and the `gradle-plugin` module
- Creates `config/checkstyle/checkstyle.xml` with the `NeedBraces` rule
- Fixes a pre-existing brace-less `if` in `SqlName.java` found by the new rule

Note: Issue #354 suggested using the CleanThat `AddBraces` mutator via Spotless, but this mutator does not exist in the version of CleanThat bundled with Spotless 8.6.0. Checkstyle's `NeedBraces` rule achieves the same outcome (build failure on missing braces).

Closes #354

## Test plan

- [ ] `./gradlew build` passes
- [ ] Introduce a brace-less `if` in any Java file and verify `./gradlew checkstyleMain` fails with a `NeedBraces` violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)