### PR TITLE
fix: enforce patched transitive deps to resolve Dependabot CVEs

### DIFF
--- a/buildSrc/src/main/kotlin/java-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-convention.gradle.kts
@@ -41,6 +41,26 @@ checkstyle {
     configFile = rootProject.file("config/checkstyle/checkstyle.xml")
 }
 
+configurations.named("checkstyle") {
+    resolutionStrategy.force(
+        "commons-beanutils:commons-beanutils:1.11.0",
+        "org.codehaus.plexus:plexus-utils:3.6.1"
+    )
+}
+
+dependencies {
+    constraints {
+        implementation("org.apache.commons:commons-lang3") {
+            version { require("3.18.0") }
+            because("Dependabot CVE: uncontrolled recursion below 3.18.0")
+        }
+        implementation("org.apache.commons:commons-compress") {
+            version { require("1.26.0") }
+            because("Dependabot CVE: DoS/OOM below 1.26.0")
+        }
+    }
+}
+
 spotless {
     java {
         cleanthat()

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -103,6 +103,13 @@ checkstyle {
     configFile = file("../../config/checkstyle/checkstyle.xml")
 }
 
+configurations.named("checkstyle") {
+    resolutionStrategy.force(
+        "commons-beanutils:commons-beanutils:1.11.0",
+        "org.codehaus.plexus:plexus-utils:3.6.1"
+    )
+}
+
 spotless {
     java {
         cleanthat()


### PR DESCRIPTION
## Summary

- Forces `commons-beanutils:1.11.0` and `plexus-utils:3.6.1` on the checkstyle tool configuration — both were pulled in at vulnerable versions by the default checkstyle 10.24.0 (alerts #32 and #33)
- Adds dependency constraints enforcing `commons-lang3 ≥ 3.18.0` and `commons-compress ≥ 1.26.0` as a floor across all Java module configurations (alerts #23, #7, #10 — already resolving to safe versions, but constraints make this explicit and Dependabot-visible)

Fixes Dependabot alerts: #32 (HIGH), #33 (HIGH). Closes #7, #10, #23 (already safe, constraints confirm floor).

## Test plan

- [x] `./gradlew :processor:dependencies --configuration checkstyle` shows `commons-beanutils:1.10.1 -> 1.11.0` and `plexus-utils:3.3.0 -> 3.6.1`
- [x] `./gradlew :processor:dependencies --configuration runtimeClasspath` shows constraints active without downgrading existing safe versions
- [x] Full `./gradlew build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)