### PR TITLE
fix: improve publish process — git tag and release docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,27 @@ Key conventions:
 
 ---
 
+## Releasing (maintainers only)
+
+1. Ensure all desired changes are on `main` and CI is green.
+2. Edit `version.gradle.kts` — remove the `-SNAPSHOT` suffix (e.g. `"0.11"`).
+3. Commit the version change and push directly to `main`:
+   ```bash
+   git commit -am "chore: release v0.11"
+   git push
+   ```
+   *(Note: this bypasses branch protection — disable the rule temporarily if needed.)*
+4. Run `./publish.bash` — this builds and publishes to Maven Central and the Gradle Plugin Portal,
+   creates a `v0.11` git tag, pushes commits and tag, and triggers the docs deployment workflow.
+5. Edit `version.gradle.kts` — bump to the next SNAPSHOT (e.g. `"0.12-SNAPSHOT"`).
+6. Commit and push:
+   ```bash
+   git commit -am "chore: bump version to 0.12-SNAPSHOT"
+   git push
+   ```
+
+---
+
 ## Licence
 
 Kiwiproc is licensed under the [Apache 2.0 Licence](LICENSE). By submitting a pull request, you agree that your contributions will be licensed under the same terms.

--- a/publish.bash
+++ b/publish.bash
@@ -12,6 +12,8 @@ if grep SNAPSHOT version.gradle.kts; then
   exit 2
 fi
 
+VERSION=$(grep -oP '(?<=")[^"]+(?=")' version.gradle.kts)
+
 # publish plugin library to maven
 pushd gradle-plugin/
 gw $GW_OPTS clean
@@ -27,8 +29,9 @@ gw $GW_OPTS publishAllPublicationsToMavenCentralRepository
 pushd gradle-plugin/
 gw $GW_OPTS publishPlugins
 popd
-# ensure release commit is on remote before triggering docs
-git push
+# tag the release commit and push commits + tag together
+git tag -a "v$VERSION" -m "Release v$VERSION"
+git push --follow-tags
 # publish docs
 gh workflow run docs.yml
 


### PR DESCRIPTION
## Summary

- Extract version from `version.gradle.kts` in `publish.bash` and create an annotated git tag (`v$VERSION`) after artifacts are published
- Push commits and the new tag together with `git push --follow-tags`
- Add a **Releasing (maintainers only)** section to `CONTRIBUTING.md` documenting the full manual release sequence

## Test plan

- [ ] Verify `bash -n publish.bash` reports no syntax errors
- [ ] On next release: confirm `v<version>` tag appears on GitHub after running the script

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)