### PR TITLE
feat: validate Java enum constants against PostgreSQL native enum at compile time

### DIFF
--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/KiwiProcessor.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/KiwiProcessor.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.processing.*;
 import javax.lang.model.SourceVersion;
@@ -145,7 +146,8 @@ public class KiwiProcessor extends AnnotationProcessor {
             parameterMapping.forEach(
                     (col, mpi) -> logger.note(methodElement, "col " + col.index() + " parameter " + mpi.name()));
         }
-        var typeValidator = new TypeValidator(logger, methodElement, coreTypes, config.debug());
+        Function<String, List<String>> nativeEnumLookup = typeName -> databaseWrapper.queryEnumConstants(typeName);
+        var typeValidator = new TypeValidator(logger, methodElement, coreTypes, config.debug(), nativeEnumLookup);
         if (!typeValidator.validateParameters(parameterMapping, kind)) {
             return null;
         }

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/KiwiProcessor.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/KiwiProcessor.java
@@ -12,7 +12,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.processing.*;
 import javax.lang.model.SourceVersion;
@@ -146,7 +145,7 @@ public class KiwiProcessor extends AnnotationProcessor {
             parameterMapping.forEach(
                     (col, mpi) -> logger.note(methodElement, "col " + col.index() + " parameter " + mpi.name()));
         }
-        Function<String, List<String>> nativeEnumLookup = typeName -> databaseWrapper.queryEnumConstants(typeName);
+        NativeEnumLookup nativeEnumLookup = databaseWrapper::queryEnumConstants;
         var typeValidator = new TypeValidator(logger, methodElement, coreTypes, config.debug(), nativeEnumLookup);
         if (!typeValidator.validateParameters(parameterMapping, kind)) {
             return null;

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/NativeEnumLookup.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/NativeEnumLookup.java
@@ -1,0 +1,9 @@
+/* (C) Edward Harman 2024 */
+package org.ethelred.kiwiproc.processor;
+
+import java.util.List;
+
+@FunctionalInterface
+public interface NativeEnumLookup {
+    List<String> getConstants(String typeName);
+}

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/TypeValidator.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/TypeValidator.java
@@ -6,12 +6,18 @@ import static org.ethelred.kiwiproc.processor.DAOResultMapping.INVALID;
 import com.karuslabs.utilitary.Logger;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import javax.lang.model.element.Element;
 import org.ethelred.kiwiproc.meta.ColumnMetaData;
 import org.ethelred.kiwiproc.processor.types.*;
 import org.ethelred.kiwiproc.processor.types.ObjectType;
 
-public record TypeValidator(Logger logger, Element element, CoreTypes coreTypes, boolean debug) {
+public record TypeValidator(
+        Logger logger,
+        Element element,
+        CoreTypes coreTypes,
+        boolean debug,
+        Function<String, List<String>> nativeEnumLookup) {
 
     public boolean validateParameters(Map<ColumnMetaData, MethodParameterInfo> parameterMapping, QueryMethodKind kind) {
         boolean result = true;
@@ -35,11 +41,57 @@ public record TypeValidator(Logger logger, Element element, CoreTypes coreTypes,
             logger.error(element, "SqlBatch method must have at least one iterable parameter");
         }
 
+        for (var entry : parameterMapping.entrySet()) {
+            var paramType = entry.getValue().type();
+            if (kind == QueryMethodKind.BATCH && paramType instanceof CollectionType ct) {
+                paramType = ct.containedType();
+            }
+            if (paramType instanceof EnumType enumType) {
+                if (!withElement(entry.getValue().variableElement()).validateEnumParameter(enumType, entry.getKey())) {
+                    result = false;
+                }
+            }
+        }
+
         return result;
     }
 
+    private boolean validateEnumParameter(EnumType enumType, ColumnMetaData columnMetaData) {
+        var pgConstants = nativeEnumLookup.apply(columnMetaData.dbType());
+        if (pgConstants.isEmpty()) {
+            return true;
+        }
+        var extraJavaConstants = enumType.constants().stream()
+                .filter(c -> !pgConstants.contains(c))
+                .toList();
+        if (!extraJavaConstants.isEmpty()) {
+            logger.error(
+                    element,
+                    "Java enum %s has constant(s) %s not present in PostgreSQL enum type '%s'"
+                            .formatted(enumType.className(), extraJavaConstants, columnMetaData.dbType()));
+            return false;
+        }
+        return true;
+    }
+
+    private void validateEnumReturn(EnumType enumType, ColumnMetaData columnMetaData) {
+        var pgConstants = nativeEnumLookup.apply(columnMetaData.dbType());
+        if (pgConstants.isEmpty()) {
+            return;
+        }
+        var extraPgConstants = pgConstants.stream()
+                .filter(c -> !enumType.constants().contains(c))
+                .toList();
+        if (!extraPgConstants.isEmpty()) {
+            logger.warn(
+                    element,
+                    "PostgreSQL enum '%s' has value(s) %s with no corresponding %s constant; reading such a value will throw IllegalArgumentException"
+                            .formatted(columnMetaData.dbType(), extraPgConstants, enumType.className()));
+        }
+    }
+
     private TypeValidator withElement(Element element) {
-        return new TypeValidator(logger, element, coreTypes, debug);
+        return new TypeValidator(logger, element, coreTypes, debug, nativeEnumLookup);
     }
 
     private boolean validateSingleParameter(KiwiType parameterType, KiwiType columnType) {
@@ -206,6 +258,9 @@ public record TypeValidator(Logger logger, Element element, CoreTypes coreTypes,
                 mappedColumn.accept(t);
                 KiwiType target = context.asParameter() ? returnType.withIsNullable(false) : returnType;
                 Conversion conversion = validateCompatible(columnType, target);
+                if (target instanceof EnumType enumType) {
+                    validateEnumReturn(enumType, t);
+                }
                 return new DAOResultMapping(
                         new DAOResultColumn(t.name(), sqlTypeMapping, target, context.resultPart(), conversion));
             }
@@ -227,6 +282,9 @@ public record TypeValidator(Logger logger, Element element, CoreTypes coreTypes,
                             if (!conversion.isValid()) {
                                 reportError("Missing or incompatible column type %s for component %s type %s"
                                         .formatted(columnType, component.name(), component.type()));
+                            }
+                            if (component.type() instanceof EnumType enumType) {
+                                validateEnumReturn(enumType, columnMetaData);
                             }
                             return new DAOResultColumn(
                                     columnMetaData.name(),

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/TypeValidator.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/TypeValidator.java
@@ -6,18 +6,13 @@ import static org.ethelred.kiwiproc.processor.DAOResultMapping.INVALID;
 import com.karuslabs.utilitary.Logger;
 import java.util.*;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import javax.lang.model.element.Element;
 import org.ethelred.kiwiproc.meta.ColumnMetaData;
 import org.ethelred.kiwiproc.processor.types.*;
 import org.ethelred.kiwiproc.processor.types.ObjectType;
 
 public record TypeValidator(
-        Logger logger,
-        Element element,
-        CoreTypes coreTypes,
-        boolean debug,
-        Function<String, List<String>> nativeEnumLookup) {
+        Logger logger, Element element, CoreTypes coreTypes, boolean debug, NativeEnumLookup nativeEnumLookup) {
 
     public boolean validateParameters(Map<ColumnMetaData, MethodParameterInfo> parameterMapping, QueryMethodKind kind) {
         boolean result = true;
@@ -57,7 +52,7 @@ public record TypeValidator(
     }
 
     private boolean validateEnumParameter(EnumType enumType, ColumnMetaData columnMetaData) {
-        var pgConstants = nativeEnumLookup.apply(columnMetaData.dbType());
+        var pgConstants = nativeEnumLookup.getConstants(columnMetaData.dbType());
         if (pgConstants.isEmpty()) {
             return true;
         }
@@ -75,7 +70,7 @@ public record TypeValidator(
     }
 
     private void validateEnumReturn(EnumType enumType, ColumnMetaData columnMetaData) {
-        var pgConstants = nativeEnumLookup.apply(columnMetaData.dbType());
+        var pgConstants = nativeEnumLookup.getConstants(columnMetaData.dbType());
         if (pgConstants.isEmpty()) {
             return;
         }

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/types/EnumType.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/types/EnumType.java
@@ -1,7 +1,15 @@
 /* (C) Edward Harman 2024 */
 package org.ethelred.kiwiproc.processor.types;
 
-public record EnumType(String packageName, String className, boolean isNullable) implements KiwiType {
+import java.util.List;
+
+public record EnumType(String packageName, String className, boolean isNullable, List<String> constants)
+        implements KiwiType {
+
+    public EnumType(String packageName, String className, boolean isNullable) {
+        this(packageName, className, isNullable, List.of());
+    }
+
     @Override
     public String toString() {
         return className + "(enum)" + (isNullable ? "/nullable" : "/non-null");
@@ -9,7 +17,7 @@ public record EnumType(String packageName, String className, boolean isNullable)
 
     @Override
     public EnumType withIsNullable(boolean newValue) {
-        return new EnumType(packageName, className, newValue);
+        return new EnumType(packageName, className, newValue, constants);
     }
 
     @Override

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/types/EnumTypeHandler.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/types/EnumTypeHandler.java
@@ -12,7 +12,12 @@ class EnumTypeHandler extends DeclaredTypeHandler {
 
     @Override
     public KiwiType apply(DeclaredType t) {
-        return new EnumType(utils.packageName(t), utils.className(t), utils.isNullable(t));
+        var typeElement = (TypeElement) t.asElement();
+        var constants = typeElement.getEnclosedElements().stream()
+                .filter(e -> e.getKind() == ElementKind.ENUM_CONSTANT)
+                .map(e -> e.getSimpleName().toString())
+                .toList();
+        return new EnumType(utils.packageName(t), utils.className(t), utils.isNullable(t), constants);
     }
 
     @Override

--- a/processor/src/test/java/org/ethelred/kiwiproc/processor/ProcessorMethodTestCase.java
+++ b/processor/src/test/java/org/ethelred/kiwiproc/processor/ProcessorMethodTestCase.java
@@ -16,6 +16,7 @@ class ProcessorMethodTestCase {
     Map<String, String> additionalSources = new HashMap<>();
     int expectedErrorCount = -1;
     Set<String> expectedErrorMessages = new HashSet<>();
+    Set<String> expectedWarningMessages = new HashSet<>();
 
     @Nullable String displayName;
 
@@ -42,6 +43,11 @@ class ProcessorMethodTestCase {
 
     ProcessorMethodTestCase withExpectedErrorMessage(String message) {
         expectedErrorMessages.add(message);
+        return this;
+    }
+
+    ProcessorMethodTestCase withExpectedWarningMessage(String message) {
+        expectedWarningMessages.add(message);
         return this;
     }
 

--- a/processor/src/test/java/org/ethelred/kiwiproc/processor/ProcessorTest.java
+++ b/processor/src/test/java/org/ethelred/kiwiproc/processor/ProcessorTest.java
@@ -153,7 +153,7 @@ public class ProcessorTest {
 
                                         @DAO
                                         public interface MyDAO {
-                                            @SqlQuery(sql = "SELECT * FROM restaurant WHERE name like :search || '%'")
+                                            @SqlQuery(sql = "SELECT id, name, tables, chain FROM restaurant WHERE name like :search || '%'")
                                             List<Restaurant> findRestaurantsByName(String search);
                                         }
                                         """));
@@ -179,6 +179,9 @@ public class ProcessorTest {
         assertThat(compilation).hadErrorCount(testCase.expectedErrorCount);
         for (var message : testCase.expectedErrorMessages) {
             assertThat(compilation).hadErrorContaining(message);
+        }
+        for (var message : testCase.expectedWarningMessages) {
+            assertThat(compilation).hadWarningContaining(message);
         }
     }
 
@@ -242,7 +245,7 @@ public class ProcessorTest {
                         .withDisplayName("A SqlBatch method compiles when it has an int array return type.")
                         .succeeds(),
                 method("""
-                        @SqlQuery(sql = "SELECT * FROM restaurant WHERE name like :search || '%'")
+                        @SqlQuery(sql = "SELECT id, name, tables, chain FROM restaurant WHERE name like :search || '%'")
                         List<Restaurant> findRestaurantsByName(String search);
                         """)
                         .withAdditionalSource("com.example.Restaurant", """
@@ -258,7 +261,7 @@ public class ProcessorTest {
                         .withExpectedErrorMessage("Unsupported return type")
                         .withExpectedErrorMessage("Invalid return type"),
                 method("""
-                        @SqlQuery(sql = "SELECT * FROM restaurant WHERE name like :search || '%'")
+                        @SqlQuery(sql = "SELECT id, name, tables, chain FROM restaurant WHERE name like :search || '%'")
                         List<Restaurant> findRestaurantsByName(String search);
                         """)
                         .withAdditionalSource("com.example.Restaurant", """
@@ -381,6 +384,42 @@ public class ProcessorTest {
                         """)
                         .withDisplayName(
                                 "[SPEC GAP] A SqlQuery method succeeds even when a record parameter has no components matching any placeholder (spec requires error).")
+                        .succeeds(),
+                // native PG enum validation — Direction 1: Java has extra constant not in PG enum
+                method("""
+                        enum RestaurantStatus { OPEN, CLOSED, UNKNOWN }
+                        @SqlUpdate(sql = "UPDATE restaurant SET status = :status WHERE name = :name")
+                        void updateStatus(String name, RestaurantStatus status);
+                        """)
+                        .withDisplayName("A SqlUpdate with a Java enum constant not in the PG native enum type fails.")
+                        .withExpectedErrorMessage("UNKNOWN")
+                        .withExpectedErrorCount(2),
+                // native PG enum validation — Direction 1: Java enum exactly matches PG enum
+                method("""
+                        enum RestaurantStatus { OPEN, CLOSED }
+                        @SqlUpdate(sql = "UPDATE restaurant SET status = :status WHERE name = :name")
+                        void updateStatus(String name, RestaurantStatus status);
+                        """)
+                        .withDisplayName(
+                                "A SqlUpdate with a Java enum exactly matching the PG native enum type compiles.")
+                        .succeeds(),
+                // native PG enum validation — Direction 2: PG enum has value with no Java constant
+                method("""
+                        enum PartialStatus { OPEN }
+                        @SqlQuery(sql = "SELECT status FROM restaurant WHERE name = :name")
+                        @org.jspecify.annotations.Nullable PartialStatus getStatus(String name);
+                        """)
+                        .withDisplayName("A SqlQuery whose Java enum is missing a PG native enum value warns.")
+                        .withExpectedWarningMessage("CLOSED")
+                        .succeeds(),
+                // native PG enum validation — Direction 2: Java enum covers all PG enum values
+                method("""
+                        enum RestaurantStatus { OPEN, CLOSED }
+                        @SqlQuery(sql = "SELECT status FROM restaurant WHERE name = :name")
+                        @org.jspecify.annotations.Nullable RestaurantStatus getStatus(String name);
+                        """)
+                        .withDisplayName(
+                                "A SqlQuery whose Java enum covers all PG native enum values compiles without a missing-constant warning.")
                         .succeeds());
     }
 }

--- a/processor/src/test/java/org/ethelred/kiwiproc/processor/TypeValidatorTest.java
+++ b/processor/src/test/java/org/ethelred/kiwiproc/processor/TypeValidatorTest.java
@@ -30,7 +30,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class TypeValidatorTest {
-    TypeValidator validator = new TypeValidator(mockLogger(), mockMethodElement(), new CoreTypes(), false);
+    TypeValidator validator =
+            new TypeValidator(mockLogger(), mockMethodElement(), new CoreTypes(), false, typeName -> List.of());
     Set<String> messages = new HashSet<>();
     static int colCount = 1;
 

--- a/processor/src/test/resources/changelogs/RestaurantStatus.sql
+++ b/processor/src/test/resources/changelogs/RestaurantStatus.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+--changeset edward3h:4
+CREATE TYPE restaurant_status AS ENUM ('OPEN', 'CLOSED');
+ALTER TABLE restaurant ADD COLUMN status restaurant_status;

--- a/querymeta/src/main/java/org/ethelred/kiwiproc/meta/DatabaseDialect.java
+++ b/querymeta/src/main/java/org/ethelred/kiwiproc/meta/DatabaseDialect.java
@@ -16,6 +16,10 @@ public interface DatabaseDialect {
 
     @Nullable ArrayComponent componentType(Connection connection, int columnType, String columnTypeName);
 
+    default List<String> queryEnumConstants(Connection connection, String typeName) throws SQLException {
+        return List.of();
+    }
+
     default String normalizeColumnName(String name) {
         return name;
     }

--- a/querymeta/src/main/java/org/ethelred/kiwiproc/meta/DatabaseWrapper.java
+++ b/querymeta/src/main/java/org/ethelred/kiwiproc/meta/DatabaseWrapper.java
@@ -3,6 +3,7 @@ package org.ethelred.kiwiproc.meta;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.regex.Pattern;
 import javax.sql.DataSource;
 import org.ethelred.kiwiproc.processorconfig.DataSourceConfig;
@@ -40,6 +41,14 @@ public class DatabaseWrapper {
 
     /* package visible for testing */ Connection getConnection() throws SQLException {
         return dataSource.getConnection();
+    }
+
+    public List<String> queryEnumConstants(String typeName) {
+        try (var connection = getConnection()) {
+            return dialect.queryEnumConstants(connection, typeName);
+        } catch (SQLException e) {
+            return List.of();
+        }
     }
 
     @SuppressWarnings("SqlSourceToSinkFlow")

--- a/querymeta/src/main/java/org/ethelred/kiwiproc/meta/PostgresDialect.java
+++ b/querymeta/src/main/java/org/ethelred/kiwiproc/meta/PostgresDialect.java
@@ -5,6 +5,8 @@ import java.sql.Connection;
 import java.sql.JDBCType;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import javax.sql.DataSource;
 import org.ethelred.kiwiproc.processorconfig.DataSourceConfig;
@@ -27,6 +29,26 @@ public class PostgresDialect implements DatabaseDialect {
             ds.setPassword(config.password());
         }
         return ds;
+    }
+
+    @Override
+    public List<String> queryEnumConstants(Connection connection, String typeName) throws SQLException {
+        var sql = """
+                SELECT e.enumlabel
+                FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
+                WHERE t.typname = ?
+                ORDER BY e.enumsortorder
+                """;
+        try (var stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, typeName);
+            try (var rs = stmt.executeQuery()) {
+                var result = new ArrayList<String>();
+                while (rs.next()) {
+                    result.add(rs.getString(1));
+                }
+                return List.copyOf(result);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary

Implements issue #355 — compile-time validation of Java enum constants against PostgreSQL native enum types.

**Direction 1 (compile error):** If a Java enum parameter has a constant not in the PostgreSQL enum, kiwiproc now emits a compile error. Any INSERT of that constant would fail at runtime anyway.

**Direction 2 (compile warning):** If the PostgreSQL enum has a value with no corresponding Java constant, kiwiproc emits a specific warning naming the missing values, upgrading the existing generic `IllegalArgumentException` warning.

## Changes

- `DatabaseDialect.queryEnumConstants()` — default returns empty list (H2, MySQL: no validation)
- `PostgresDialect` overrides with a `pg_type`/`pg_enum` join query
- `DatabaseWrapper.queryEnumConstants()` delegates to dialect; swallows `SQLException` so a DB error silently skips validation rather than blocking compilation
- `EnumType` gains a `List<String> constants()` component, populated at annotation-processing time by `EnumTypeHandler` from the Java source; 3-arg backward-compat constructor added
- `TypeValidator` receives a `Function<String, List<String>> nativeEnumLookup` and adds `validateEnumParameter()` (Direction 1) and `validateEnumReturn()` (Direction 2) methods
- `ProcessorTest`: adds a `restaurant_status` PG enum to the test schema and four new parameterised test cases covering both directions

## Test plan

- [x] `./gradlew :processor:test` — all 409 tests pass, including 4 new enum validation cases
- [x] `./gradlew build` — full build with all integration tests passes

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)