### PR TITLE
docs: add Maven setup documentation (closes #53)

### DIFF
--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -18,6 +18,8 @@ include::databases.adoc[]
 
 include::gradle_plugin.adoc[]
 
+include::maven_setup.adoc[]
+
 == API Reference
 
 * link:javadoc/shared/index.html[Annotations API (shared)]

--- a/docs/src/docs/asciidoc/maven_setup.adoc
+++ b/docs/src/docs/asciidoc/maven_setup.adoc
@@ -1,0 +1,127 @@
+:docinfo: shared
+
+== Maven Setup
+
+Unlike the Gradle plugin, which automatically manages an embedded database and wires up the annotation processor, Maven users must configure these steps manually.
+You will need an external database available at build time so the annotation processor can introspect the schema.
+
+=== Dependencies
+
+Add the following to your `pom.xml`:
+
+[source,xml,indent=0,subs="verbatim,attributes"]
+----
+<dependencies>
+    <!-- kiwiproc annotations -->
+    <dependency>
+        <groupId>org.ethelred.kiwiproc</groupId>
+        <artifactId>shared</artifactId>
+        <version>{revnumber}</version>
+    </dependency>
+    <!-- kiwiproc runtime (required at runtime) -->
+    <dependency>
+        <groupId>org.ethelred.kiwiproc</groupId>
+        <artifactId>runtime</artifactId>
+        <version>{revnumber}</version>
+    </dependency>
+    <!-- Jakarta inject API -->
+    <dependency>
+        <groupId>jakarta.inject</groupId>
+        <artifactId>jakarta.inject-api</artifactId>
+        <version>2.0.1</version>
+    </dependency>
+</dependencies>
+----
+
+=== Processor Configuration File
+
+The annotation processor requires a JSON configuration file that describes how to connect to the database.
+Create a file named `kiwiproc-config.json` in the root of your project:
+
+[source,json]
+----
+{
+  "dataSources": {
+    "default": {
+      "named": "default",
+      "url": "jdbc:postgresql://localhost:5432/mydb", // <1>
+      "username": "postgres",
+      "password": null,
+      "database": null,
+      "driverClassName": null
+    }
+  },
+  "dependencyInjectionStyle": "JAKARTA", // <2>
+  "debug": false
+}
+----
+<1> Replace with the JDBC URL of your build-time database. The database must already have your schema applied.
+<2> Use `SPRING` for Spring Boot projects (see xref:#maven-spring[Spring Boot]).
+
+TIP: You may apply your schema migrations manually, or use the Liquibase Maven plugin before the compile phase to automate this.
+
+=== Compiler Plugin Configuration
+
+Configure `maven-compiler-plugin` to use the kiwiproc annotation processor and pass it the config file path:
+
+[source,xml,indent=0,subs="verbatim,attributes"]
+----
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <annotationProcessorPaths>
+                    <path>
+                        <groupId>org.ethelred.kiwiproc</groupId>
+                        <artifactId>processor</artifactId>
+                        <version>{revnumber}</version>
+                    </path>
+                </annotationProcessorPaths>
+                <compilerArgs>
+                    <arg>-Aorg.ethelred.kiwiproc.configuration=${project.basedir}/kiwiproc-config.json</arg> // <1>
+                </compilerArgs>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+----
+<1> Adjust the path if you place `kiwiproc-config.json` elsewhere.
+
+[[maven-spring]]
+=== Spring Boot
+
+Add the Spring autoconfigure module and change `dependencyInjectionStyle` to `SPRING`:
+
+[source,xml,indent=0,subs="verbatim,attributes"]
+----
+<dependency>
+    <groupId>org.ethelred.kiwiproc</groupId>
+    <artifactId>spring-autoconfigure</artifactId>
+    <version>{revnumber}</version>
+</dependency>
+----
+
+And in `kiwiproc-config.json`:
+
+[source,json]
+----
+{
+  "dataSources": {
+    "default": {
+      "named": "default",
+      "url": "jdbc:postgresql://localhost:5432/mydb",
+      "username": "postgres",
+      "password": null,
+      "database": null,
+      "driverClassName": null
+    }
+  },
+  "dependencyInjectionStyle": "SPRING",
+  "debug": false
+}
+----
+
+The `spring-autoconfigure` module registers the primary `DataSource` bean under the `"default"` qualifier automatically, so no manual `DataSource` bean definition is needed.
+See <<_framework_support,Framework Support>> for further details.

--- a/docs/src/docs/asciidoc/quick_start.adoc
+++ b/docs/src/docs/asciidoc/quick_start.adoc
@@ -5,7 +5,11 @@
 
 == Quick Start
 
-=== Gradle Configuration
+=== Build Tool Configuration
+
+NOTE: Maven users should refer to <<_maven_setup,Maven Setup>> for dependency and compiler plugin configuration.
+
+==== Gradle
 
 Add the Gradle plugin. By default, it will:
 


### PR DESCRIPTION
## Summary

- Adds a new `maven_setup.adoc` section documenting how to use kiwiproc from Maven
- Covers `pom.xml` dependencies, the `kiwiproc-config.json` processor config file, `maven-compiler-plugin` wiring, and a Spring Boot variant
- Updates `quick_start.adoc` to point Maven users to the new section
- Updates `index.adoc` to include the new page after the Gradle plugin docs

## Test Plan

- [x] `./gradlew :docs:asciidoctor` builds successfully with no errors or broken xrefs
- [x] Version attribute `{revnumber}` renders correctly throughout the new section
- [x] Cross-reference from Quick Start to Maven Setup resolves to correct anchor
- [x] Full build passes (`./gradlew build`)