### PR TITLE
fix: avoid generated variable collision for result column named "value" (GH#379)

### DIFF
--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/generator/InstanceGenerator.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/generator/InstanceGenerator.java
@@ -198,10 +198,10 @@ public class InstanceGenerator {
             for (ResultPart resultPart : ResultPart.values()) {
                 var componentClass = containerBuilder.componentTypeFor(resultPart);
                 if (componentClass != null) {
-                    var resultVar = ctx.patchName(prefixName(resultPart, "Value"));
+                    var resultVar = ctx.patchName(resultPart, prefixName(resultPart, "Value"));
                     var params = columns.stream()
                             .filter(column -> resultPart.equals(column.resultPart()))
-                            .map(p -> CodeBlock.of("$L", ctx.patchedNameFor(columnName(p))))
+                            .map(p -> CodeBlock.of("$L", ctx.patchedNameFor(p)))
                             .collect(CodeBlock.joining(",\n"));
                     params = CodeBlock.builder().indent().add(params).unindent().build();
                     builder.add("""
@@ -263,10 +263,10 @@ public class InstanceGenerator {
 
         // Construct record if element type is not simple; otherwise return raw column value
         if (!elementType.isSimple()) {
-            var resultVar = ctx.patchName(prefixName(ResultPart.SIMPLE, "Value"));
+            var resultVar = ctx.patchName(ResultPart.SIMPLE, prefixName(ResultPart.SIMPLE, "Value"));
             var params = columns.stream()
                     .filter(column -> ResultPart.SIMPLE.equals(column.resultPart()))
-                    .map(p -> CodeBlock.of("$L", ctx.patchedNameFor(columnName(p))))
+                    .map(p -> CodeBlock.of("$L", ctx.patchedNameFor(p)))
                     .collect(CodeBlock.joining(",\n"));
             params = CodeBlock.builder().indent().add(params).unindent().build();
             builder.add("""
@@ -280,7 +280,7 @@ public class InstanceGenerator {
                     .filter(c -> c.resultPart() == ResultPart.SIMPLE)
                     .findFirst()
                     .orElseThrow(() -> new IllegalStateException("No SIMPLE column for stream query"));
-            String patchedValueVariable = ctx.patchedNameFor(columnName(firstSimple));
+            String patchedValueVariable = ctx.patchedNameFor(firstSimple);
             builder.addStatement("return $L", patchedValueVariable);
         }
 
@@ -317,7 +317,7 @@ public class InstanceGenerator {
                         .addStatement("$L = null", rawName)
                         .endControlFlow();
             }
-            var varName = ctx.patchName(columnName(column));
+            var varName = ctx.patchName(column, columnName(column));
             conversionGenerator.buildConversion(
                     builder,
                     ctx,
@@ -471,10 +471,9 @@ public class InstanceGenerator {
         @Override
         public CodeBlock add() {
             var builder = CodeBlock.builder();
-            var valueVariable = returnType.valueComponentType().isSimple()
-                    ? columnName(firstColumnOfPart(ResultPart.SIMPLE))
-                    : prefixName(ResultPart.SIMPLE, "Value");
-            var patchedValueVariable = ctx.patchedNameFor(valueVariable);
+            var patchedValueVariable = returnType.valueComponentType().isSimple()
+                    ? ctx.patchedNameFor(firstColumnOfPart(ResultPart.SIMPLE))
+                    : ctx.patchedNameFor(ResultPart.SIMPLE);
             if (returnType instanceof OptionalType optionalType) {
                 if (!returnType.valueComponentType().isNullable()) {
                     return builder.addStatement("return $T.of($L)", optionalType.optionalClass(), patchedValueVariable)
@@ -530,10 +529,9 @@ public class InstanceGenerator {
 
         @Override
         public CodeBlock add() {
-            var valueVariable = returnType.valueComponentType().isSimple()
-                    ? columnName(firstColumnOfPart(ResultPart.SIMPLE))
-                    : prefixName(ResultPart.SIMPLE, "Value");
-            String patchedValueVariable = ctx.patchedNameFor(valueVariable);
+            String patchedValueVariable = returnType.valueComponentType().isSimple()
+                    ? ctx.patchedNameFor(firstColumnOfPart(ResultPart.SIMPLE))
+                    : ctx.patchedNameFor(ResultPart.SIMPLE);
             return CodeBlock.builder()
                     .beginControlFlow("if ($L != null)", patchedValueVariable)
                     .addStatement("$L.add($L)", containerVariable, patchedValueVariable)
@@ -605,13 +603,12 @@ public class InstanceGenerator {
 
         @Override
         public CodeBlock add() {
-            var keyVariable =
-                    returnType.keyType().isSimple() ? columnName(firstColumnOfPart(KEY)) : prefixName(KEY, "Value");
-            var patchedKeyVariable = ctx.patchedNameFor(keyVariable);
-            var valueVariable = returnType.valueComponentType().isSimple()
-                    ? columnName(firstColumnOfPart(VALUE))
-                    : prefixName(VALUE, "Value");
-            var patchedValueVariable = ctx.patchedNameFor(valueVariable);
+            var patchedKeyVariable = returnType.keyType().isSimple()
+                    ? ctx.patchedNameFor(firstColumnOfPart(KEY))
+                    : ctx.patchedNameFor(KEY);
+            var patchedValueVariable = returnType.valueComponentType().isSimple()
+                    ? ctx.patchedNameFor(firstColumnOfPart(VALUE))
+                    : ctx.patchedNameFor(VALUE);
             var builder = CodeBlock.builder();
             if (returnType.keyType().isNullable()) {
                 builder.beginControlFlow("if ($L != null)", patchedKeyVariable);

--- a/processor/src/main/java/org/ethelred/kiwiproc/processor/generator/MethodContext.java
+++ b/processor/src/main/java/org/ethelred/kiwiproc/processor/generator/MethodContext.java
@@ -9,24 +9,30 @@ import org.jspecify.annotations.Nullable;
 
 class MethodContext {
     private final Set<String> parameterNames = new HashSet<>();
-    private final Map<String, String> patchedNames = new HashMap<>();
+    private final Map<Object, String> patchedNames = new HashMap<>();
     private int patchedNameCount = 0;
 
     void registerParameterName(String name) {
         parameterNames.add(name);
     }
 
+    // one-off name, never re-looked-up, so always allocate fresh rather than caching by name
     String patchName(String name) {
-        return patchedNames.computeIfAbsent(name, k -> {
-            var newName = k;
+        return patchName(new Object(), name);
+    }
+
+    // key must uniquely identify the logical entity, since two entities can request the same name
+    String patchName(Object key, String name) {
+        return patchedNames.computeIfAbsent(key, k -> {
+            var newName = name;
             while (parameterNames.contains(newName) || patchedNames.containsValue(newName)) {
-                newName = k + (++patchedNameCount);
+                newName = name + (++patchedNameCount);
             }
             return newName;
         });
     }
 
-    @Nullable String patchedNameFor(String name) {
-        return patchedNames.get(name);
+    @Nullable String patchedNameFor(Object key) {
+        return patchedNames.get(key);
     }
 }

--- a/processor/src/test/java/org/ethelred/kiwiproc/processor/ProcessorTest.java
+++ b/processor/src/test/java/org/ethelred/kiwiproc/processor/ProcessorTest.java
@@ -467,6 +467,16 @@ public class ProcessorTest {
                         """)
                         .withDisplayName(
                                 "A SqlQuery whose Java enum covers all PG native enum values compiles without a missing-constant warning.")
+                        .succeeds(),
+                // GH#379 — result column literally named "value" collided with the synthetic
+                // record-construction variable name, causing duplicate variable declarations.
+                method("""
+                        record Counter(String name, int value) {}
+                        @SqlQuery(sql = "SELECT name, tables AS value FROM restaurant")
+                        List<Counter> findCounters();
+                        """)
+                        .withDisplayName(
+                                "A SqlQuery method compiles when a result record component is named 'value' (GH#379).")
                         .succeeds());
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #379: a `@DAO` query method whose result record has a column literally named `value` produced generated code with a duplicate local variable declaration (`var value = ...` twice), failing to compile.
- Root cause: `MethodContext.patchName` cached allocated names in a map keyed by the *requested* name string. When two unrelated entities both wanted `"value"` (the result column itself, and the synthetic per-`ResultPart` record-construction variable), the second request hit the first's cache entry and skipped collision avoidance entirely.
- Fix: key the cache by the logical entity's identity (the `DAOResultColumn` instance, or the `ResultPart` enum constant) instead of by the requested string, so distinct entities can never silently share a cache slot. One-off names (iterators, lambda locals, container variables) that are never looked up again now go through an always-fresh allocation path.

## Test plan
- [x] Added a regression test in `ProcessorTest.java` reproducing the exact reported scenario (`record Counter(String name, int value)` over `SELECT name, tables AS value FROM restaurant`); confirmed it failed with the reported compile error before the fix.
- [x] `./gradlew :processor:test` passes, including the new test.
- [x] `./gradlew build` (all modules, Spotless, Checkstyle) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)