### PR TITLE
fix: enable releases in maven-invoker IT fixture repositories

### DIFF
--- a/gradle-plugin/maven-plugin/src/functionalTest/resources/it/default-embedded-postgres/pom.xml
+++ b/gradle-plugin/maven-plugin/src/functionalTest/resources/it/default-embedded-postgres/pom.xml
@@ -18,7 +18,7 @@
         <repository>
             <id>kiwiproc-it-local</id>
             <url>${kiwiproc.it.repo.url}</url>
-            <releases><enabled>false</enabled></releases>
+            <releases><enabled>true</enabled></releases>
             <snapshots><enabled>true</enabled></snapshots>
         </repository>
     </repositories>
@@ -26,7 +26,7 @@
         <pluginRepository>
             <id>kiwiproc-it-local</id>
             <url>${kiwiproc.it.repo.url}</url>
-            <releases><enabled>false</enabled></releases>
+            <releases><enabled>true</enabled></releases>
             <snapshots><enabled>true</enabled></snapshots>
         </pluginRepository>
     </pluginRepositories>

--- a/gradle-plugin/maven-plugin/src/functionalTest/resources/it/embedded-mysql/pom.xml
+++ b/gradle-plugin/maven-plugin/src/functionalTest/resources/it/embedded-mysql/pom.xml
@@ -18,7 +18,7 @@
         <repository>
             <id>kiwiproc-it-local</id>
             <url>${kiwiproc.it.repo.url}</url>
-            <releases><enabled>false</enabled></releases>
+            <releases><enabled>true</enabled></releases>
             <snapshots><enabled>true</enabled></snapshots>
         </repository>
     </repositories>
@@ -26,7 +26,7 @@
         <pluginRepository>
             <id>kiwiproc-it-local</id>
             <url>${kiwiproc.it.repo.url}</url>
-            <releases><enabled>false</enabled></releases>
+            <releases><enabled>true</enabled></releases>
             <snapshots><enabled>true</enabled></snapshots>
         </pluginRepository>
     </pluginRepositories>

--- a/gradle-plugin/maven-plugin/src/functionalTest/resources/it/multiple-datasources/pom.xml
+++ b/gradle-plugin/maven-plugin/src/functionalTest/resources/it/multiple-datasources/pom.xml
@@ -18,7 +18,7 @@
         <repository>
             <id>kiwiproc-it-local</id>
             <url>${kiwiproc.it.repo.url}</url>
-            <releases><enabled>false</enabled></releases>
+            <releases><enabled>true</enabled></releases>
             <snapshots><enabled>true</enabled></snapshots>
         </repository>
     </repositories>
@@ -26,7 +26,7 @@
         <pluginRepository>
             <id>kiwiproc-it-local</id>
             <url>${kiwiproc.it.repo.url}</url>
-            <releases><enabled>false</enabled></releases>
+            <releases><enabled>true</enabled></releases>
             <snapshots><enabled>true</enabled></snapshots>
         </pluginRepository>
     </pluginRepositories>


### PR DESCRIPTION
## Summary
- The maven-invoker functional test fixtures for `KiwiProcMojoInvokerTest` configured their local IT repository with `<releases><enabled>false</enabled></releases>`, only allowing snapshot resolution.
- This worked while the plugin version was always `-SNAPSHOT` during development, but breaks the v0.12 release build: with a non-snapshot version, Maven skips the local IT repo and tries (and fails) to resolve `kiwiproc-maven-plugin:0.12` from Central, where it doesn't exist yet.
- Discovered while running `./publish.bash` for the v0.12 release — the build failed at `:maven-plugin:functionalTest`.

## Test plan
- [x] `gw :maven-plugin:functionalTest` passes locally with project version `0.12` (non-snapshot)
- [x] Full pre-commit build (`./gradlew build`) green