### PR TITLE
fix: resolve com.vanniktech.maven.publish classloader conflict between sibling projects

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -1,3 +1,4 @@
 plugins {
     id("com.diffplug.spotless").version("8.7.0") apply false
+    id("com.vanniktech.maven.publish") version "0.36.0" apply false
 }

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("com.gradle.plugin-publish") version "2.1.1"
     id("com.diffplug.spotless")
     id("signing")
-    id("com.vanniktech.maven.publish") version "0.36.0"
+    id("com.vanniktech.maven.publish")
 }
 
 apply(from = "../../version.gradle.kts")

--- a/gradle-plugin/processorconfig/build.gradle.kts
+++ b/gradle-plugin/processorconfig/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     checkstyle
     id("com.diffplug.spotless")
     id("signing")
-    id("com.vanniktech.maven.publish") version "0.36.0"
+    id("com.vanniktech.maven.publish")
 }
 
 apply(from = "../../version.gradle.kts")


### PR DESCRIPTION
## Summary
- `:plugin` and `:processorconfig` each independently declared `id("com.vanniktech.maven.publish") version "0.36.0"` in their own `plugins {}` blocks.
- As sibling projects in the `gradle-plugin` composite build, this loaded the plugin (and its shared `MavenCentralBuildService`) into two separate classloaders, causing `publishAllPublicationsToMavenCentralRepository` to fail with a classloader mismatch on the build service.
- This was a latent bug introduced when `:processorconfig` was extracted as a sibling of `:plugin` (GH#370 / PR #384) — never exercised by a real release attempt until the v0.12 release run.
- Fix: apply the plugin once at the `gradle-plugin` root with `apply false`, and drop the version from the two subprojects so they resolve it via the shared classpath.

## Test plan
- [x] `gw :plugin:publishAllPublicationsToMavenCentralRepository :processorconfig:publishAllPublicationsToMavenCentralRepository --dry-run` resolves cleanly (previously failed with classloader error)
- [x] Full pre-commit build (`./gradlew clean build`) green